### PR TITLE
Use gettimeofday() on OSX

### DIFF
--- a/include/bx/timer.h
+++ b/include/bx/timer.h
@@ -10,10 +10,8 @@
 
 #if BX_PLATFORM_ANDROID
 #	include <time.h> // clock, clock_gettime
-#elif BX_PLATFORM_NACL || BX_PLATFORM_LINUX
+#elif BX_PLATFORM_NACL || BX_PLATFORM_LINUX || BX_PLATFORM_OSX
 #	include <sys/time.h> // gettimeofday
-#elif BX_PLATFORM_OSX
-#	include <mach/mach_time.h> // mach_absolute_time/mach_timebase_info
 #elif BX_PLATFORM_WINDOWS
 #	include <windows.h>
 #endif // BX_PLATFORM_
@@ -30,8 +28,6 @@ namespace bx
 		int64_t i64 = li.QuadPart;
 #elif BX_PLATFORM_ANDROID || BX_PLATFORM_EMSCRIPTEN
 		int64_t i64 = clock();
-#elif BX_PLATFORM_OSX
-		int64_t i64 = mach_absolute_time();
 #elif 0 // BX_PLATFORM_LINUX
 		struct timespec now;
 		clock_gettime(CLOCK_MONOTONIC_RAW, &now);
@@ -53,10 +49,6 @@ namespace bx
 		return li.QuadPart;
 #elif BX_PLATFORM_ANDROID || BX_PLATFORM_EMSCRIPTEN
 		return CLOCKS_PER_SEC;
-#elif BX_PLATFORM_OSX
-		mach_timebase_info_data_t info;
-		mach_timebase_info(&info);
-		return (int64_t)(info.denom * 1000000) / info.numer;
 #else
 		return 1000000;
 #endif // BX_PLATFORM_


### PR DESCRIPTION
I was getting very strange numbers from mach_absolute_time(),
gettimeofday() works fine.
