### PR TITLE
Fix vsnwprintf under MSVC

### DIFF
--- a/include/bx/string.h
+++ b/include/bx/string.h
@@ -189,7 +189,7 @@ namespace bx
 	inline int32_t vsnwprintf(wchar_t* _str, size_t _count, const wchar_t* _format, va_list _argList)
 	{
 #if BX_COMPILER_MSVC
-		int32_t len = ::_vsnwprintf_s(_str, _count*sizeof(wchar_t), _count, _format, _argList);
+		int32_t len = ::_vsnwprintf_s(_str, _count, _count, _format, _argList);
 		return -1 == len ? ::_vscwprintf(_format, _argList) : len;
 #elif defined(__MINGW32__)
 		return ::vsnwprintf(_str, _count, _format, _argList);


### PR DESCRIPTION
Note that for MSVC 2010 and higher we could use standard vswprintf.
