### PR TITLE
Added missing include to os.h for osx

### DIFF
--- a/include/bx/os.h
+++ b/include/bx/os.h
@@ -12,6 +12,9 @@
 #	include <windows.h>
 #elif BX_PLATFORM_NACL || BX_PLATFORM_ANDROID || BX_PLATFORM_LINUX || BX_PLATFORM_OSX || BX_PLATFORM_IOS
 #	include <sched.h> // sched_yield
+#	if BX_PLATFORM_OSX
+#		include <pthread.h> // mach_port_t
+#	endif
 #	if BX_PLATFORM_NACL
 #		include <sys/nacl_syscalls.h> // nanosleep
 #	else


### PR DESCRIPTION
I haven't looked super closely at this other than to observe that on my OSX Lion machine I couldn't build bgfx against bx without this change because no definition for mach_port_t was in scope.
