### PR TITLE
Deleting unused 'copylib' function

### DIFF
--- a/premake/premake4.lua
+++ b/premake/premake4.lua
@@ -28,9 +28,6 @@ defines {
 dofile (BX_DIR .. "premake/toolchain.lua")
 toolchain(BX_BUILD_DIR, BX_THIRD_PARTY_DIR)
 
-function copyLib()
-end
-
 dofile "bx.lua"
 dofile "unittest++.lua"
 


### PR DESCRIPTION
"copyLib()" never used, deleting it.
