### PR TITLE
fixing include error when using clang (tested on OSX)

### DIFF
--- a/include/bx/allocator.h
+++ b/include/bx/allocator.h
@@ -13,7 +13,11 @@
 #include <new>
 
 #if BX_CONFIG_ALLOCATOR_CRT
-#	include <malloc.h>
+#   if __clang__
+#       include <mm_malloc.h>
+#   else
+#       include <malloc.h>
+#   endif
 #endif // BX_CONFIG_ALLOCATOR_CRT
 
 #if BX_CONFIG_ALLOCATOR_DEBUG


### PR DESCRIPTION
Came across this, when trying out bgfx.
Fixed it for me on osx using XCode6.1.1, should fix it for others.