### PR TITLE
bx genie scripts: use path.join to compose paths

### DIFF
--- a/scripts/genie.lua
+++ b/scripts/genie.lua
@@ -17,9 +17,9 @@ solution "bx"
 
 	language "C++"
 
-BX_DIR = (path.getabsolute("..") .. "/")
-local BX_BUILD_DIR = (BX_DIR .. ".build/")
-local BX_THIRD_PARTY_DIR = (BX_DIR .. "3rdparty/")
+BX_DIR = path.getabsolute("..")
+local BX_BUILD_DIR = path.join(BX_DIR, ".build")
+local BX_THIRD_PARTY_DIR = path.join(BX_DIR, "3rdparty")
 
 defines {
 	"BX_CONFIG_ENABLE_MSVC_LEVEL4_WARNINGS=1"
@@ -39,15 +39,15 @@ project "bx.test"
 	uuid "8a653da8-23d6-11e3-acb4-887628d43830"
 	kind "ConsoleApp"
 
-	debugdir (BX_DIR .. "tests")
+	debugdir (path.join(BX_DIR, "tests"))
 
 	removeflags {
 		"NoExceptions",
 	}
 
 	includedirs {
-		BX_DIR .. "include",
-		BX_THIRD_PARTY_DIR .. "UnitTest++/src/",
+		path.join(BX_DIR, "include"),
+		path.join(BX_THIRD_PARTY_DIR, "UnitTest++/src"),
 	}
 
 	links {
@@ -55,8 +55,8 @@ project "bx.test"
 	}
 
 	files {
-		BX_DIR .. "tests/**.cpp",
-		BX_DIR .. "tests/**.H",
+		path.join(BX_DIR, "tests/**.cpp"),
+		path.join(BX_DIR, "tests/**.H"),
 	}
 
 	configuration { "vs*" }

--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -3,7 +3,7 @@
 -- License: https://github.com/bkaradzic/bx#license-bsd-2-clause
 --
 
-local bxDir = (path.getabsolute("..") .. "/")
+local bxDir = path.getabsolute("..")
 local naclToolchain = ""
 
 function toolchain(_buildDir, _libDir)
@@ -71,7 +71,7 @@ function toolchain(_buildDir, _libDir)
 	-- Avoid error when invoking genie --help.
 	if (_ACTION == nil) then return false end
 
-	location (_buildDir .. "projects/" .. _ACTION)
+	location (path.join(_buildDir, "projects", _ACTION))
 
 	if _ACTION == "clean" then
 		os.rmdir(BUILD_DIR)
@@ -107,7 +107,7 @@ function toolchain(_buildDir, _libDir)
 			premake.gcc.cc  = "$(ANDROID_NDK_ARM)/bin/arm-linux-androideabi-gcc"
 			premake.gcc.cxx = "$(ANDROID_NDK_ARM)/bin/arm-linux-androideabi-g++"
 			premake.gcc.ar  = "$(ANDROID_NDK_ARM)/bin/arm-linux-androideabi-ar"
-			location (_buildDir .. "projects/" .. _ACTION .. "-android-arm")
+			location (path.join(_buildDir, "projects", _ACTION .. "-android-arm"))
 		end
 
 		if "android-mips" == _OPTIONS["gcc"] then
@@ -119,7 +119,7 @@ function toolchain(_buildDir, _libDir)
 			premake.gcc.cc  = "$(ANDROID_NDK_MIPS)/bin/mipsel-linux-android-gcc"
 			premake.gcc.cxx = "$(ANDROID_NDK_MIPS)/bin/mipsel-linux-android-g++"
 			premake.gcc.ar  = "$(ANDROID_NDK_MIPS)/bin/mipsel-linux-android-ar"
-			location (_buildDir .. "projects/" .. _ACTION .. "-android-mips")
+			location (path.join(_buildDir, "projects", _ACTION .. "-android-mips"))
 		end
 
 		if "android-x86" == _OPTIONS["gcc"] then
@@ -131,7 +131,7 @@ function toolchain(_buildDir, _libDir)
 			premake.gcc.cc  = "$(ANDROID_NDK_X86)/bin/i686-linux-android-gcc"
 			premake.gcc.cxx = "$(ANDROID_NDK_X86)/bin/i686-linux-android-g++"
 			premake.gcc.ar  = "$(ANDROID_NDK_X86)/bin/i686-linux-android-ar"
-			location (_buildDir .. "projects/" .. _ACTION .. "-android-x86")
+			location (path.join(_buildDir, "projects", _ACTION .. "-android-x86"))
 		end
 
 		if "asmjs" == _OPTIONS["gcc"] then
@@ -144,43 +144,43 @@ function toolchain(_buildDir, _libDir)
 			premake.gcc.cxx  = "$(EMSCRIPTEN)/em++"
 			premake.gcc.ar   = "$(EMSCRIPTEN)/emar"
 			premake.gcc.llvm = true
-			location (_buildDir .. "projects/" .. _ACTION .. "-asmjs")
+			location (path.join(_buildDir, "projects", _ACTION .. "-asmjs"))
 		end
 
 		if "freebsd" == _OPTIONS["gcc"] then
-			location (_buildDir .. "projects/" .. _ACTION .. "-freebsd")
+			location (path.join(_buildDir, "projects", _ACTION .. "-freebsd"))
 		end
 
 		if "ios-arm" == _OPTIONS["gcc"] then
 			premake.gcc.cc  = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
 			premake.gcc.cxx = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"
 			premake.gcc.ar  = "ar"
-			location (_buildDir .. "projects/" .. _ACTION .. "-ios-arm")
+			location (path.join(_buildDir, "projects", _ACTION .. "-ios-arm"))
 		end
 
 		if "ios-simulator" == _OPTIONS["gcc"] then
 			premake.gcc.cc  = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
 			premake.gcc.cxx = "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"
 			premake.gcc.ar  = "ar"
-			location (_buildDir .. "projects/" .. _ACTION .. "-ios-simulator")
+			location (path.join(_buildDir, "projects", _ACTION .. "-ios-simulator"))
 		end
 
 		if "linux-gcc" == _OPTIONS["gcc"] then
-			location (_buildDir .. "projects/" .. _ACTION .. "-linux")
+			location (path.join(_buildDir, "projects", _ACTION .. "-linux"))
 		end
 
 		if "linux-clang" == _OPTIONS["gcc"] then
 			premake.gcc.cc  = "clang"
 			premake.gcc.cxx = "clang++"
 			premake.gcc.ar  = "ar"
-			location (_buildDir .. "projects/" .. _ACTION .. "-linux-clang")
+			location (path.join(_buildDir, "projects", _ACTION .. "-linux-clang"))
 		end
 
 		if "mingw-gcc" == _OPTIONS["gcc"] then
 			premake.gcc.cc  = "$(MINGW)/bin/x86_64-w64-mingw32-gcc"
 			premake.gcc.cxx = "$(MINGW)/bin/x86_64-w64-mingw32-g++"
 			premake.gcc.ar  = "$(MINGW)/bin/ar"
-			location (_buildDir .. "projects/" .. _ACTION .. "-mingw-gcc")
+			location (path.join(_buildDir, "projects", _ACTION .. "-mingw-gcc"))
 		end
 
 		if "mingw-clang" == _OPTIONS["gcc"] then
@@ -189,7 +189,7 @@ function toolchain(_buildDir, _libDir)
 			premake.gcc.ar   = "$(MINGW)/bin/ar"
 --			premake.gcc.ar   = "$(CLANG)/bin/llvm-ar"
 --			premake.gcc.llvm = true
-			location (_buildDir .. "projects/" .. _ACTION .. "-mingw-clang")
+			location (path.join(_buildDir, "projects", _ACTION .. "-mingw-clang"))
 		end
 
 		if "nacl" == _OPTIONS["gcc"] then
@@ -208,7 +208,7 @@ function toolchain(_buildDir, _libDir)
 			premake.gcc.cc  = naclToolchain .. "gcc"
 			premake.gcc.cxx = naclToolchain .. "g++"
 			premake.gcc.ar  = naclToolchain .. "ar"
-			location (_buildDir .. "projects/" .. _ACTION .. "-nacl")
+			location (path.join(_buildDir, "projects", _ACTION .. "-nacl"))
 		end
 
 		if "nacl-arm" == _OPTIONS["gcc"] then
@@ -227,7 +227,7 @@ function toolchain(_buildDir, _libDir)
 			premake.gcc.cc  = naclToolchain .. "gcc"
 			premake.gcc.cxx = naclToolchain .. "g++"
 			premake.gcc.ar  = naclToolchain .. "ar"
-			location (_buildDir .. "projects/" .. _ACTION .. "-nacl-arm")
+			location (path.join(_buildDir, "projects", _ACTION .. "-nacl-arm"))
 		end
 
 		if "osx" == _OPTIONS["gcc"] then
@@ -237,7 +237,7 @@ function toolchain(_buildDir, _libDir)
 				premake.gcc.cxx = osxToolchain .. "clang++"
 				premake.gcc.ar  = osxToolchain .. "ar"
 			end
-			location (_buildDir .. "projects/" .. _ACTION .. "-osx")
+			location (path.join(_buildDir, "projects", _ACTION .. "-osx"))
 		end
 
 		if "pnacl" == _OPTIONS["gcc"] then
@@ -256,7 +256,7 @@ function toolchain(_buildDir, _libDir)
 			premake.gcc.cc  = naclToolchain .. "clang"
 			premake.gcc.cxx = naclToolchain .. "clang++"
 			premake.gcc.ar  = naclToolchain .. "ar"
-			location (_buildDir .. "projects/" .. _ACTION .. "-pnacl")
+			location (path.join(_buildDir, "projects", _ACTION .. "-pnacl"))
 		end
 
 		if "qnx-arm" == _OPTIONS["gcc"] then
@@ -268,38 +268,38 @@ function toolchain(_buildDir, _libDir)
 			premake.gcc.cc  = "$(QNX_HOST)/usr/bin/arm-unknown-nto-qnx8.0.0eabi-gcc"
 			premake.gcc.cxx = "$(QNX_HOST)/usr/bin/arm-unknown-nto-qnx8.0.0eabi-g++"
 			premake.gcc.ar  = "$(QNX_HOST)/usr/bin/arm-unknown-nto-qnx8.0.0eabi-ar"
-			location (_buildDir .. "projects/" .. _ACTION .. "-qnx-arm")
+			location (path.join(_buildDir, "projects", _ACTION .. "-qnx-arm"))
 		end
 
 		if "rpi" == _OPTIONS["gcc"] then
-			location (_buildDir .. "projects/" .. _ACTION .. "-rpi")
+			location (path.join(_buildDir, "projects", _ACTION .. "-rpi"))
 		end
 	elseif _ACTION == "vs2012" or _ACTION == "vs2013" or _ACTION == "vs2015" then
 
 		if (_ACTION .. "-clang") == _OPTIONS["vs"] then
 			premake.vstudio.toolset = ("LLVM-" .. _ACTION)
-			location (_buildDir .. "projects/" .. _ACTION .. "-clang")
+			location (path.join(_buildDir, "projects", _ACTION .. "-clang"))
 		end
 
 		if "winphone8" == _OPTIONS["vs"] then
 			premake.vstudio.toolset = "v110_wp80"
-			location (_buildDir .. "projects/" .. _ACTION .. "-winphone8")
+			location (path.join(_buildDir, "projects", _ACTION .. "-winphone8"))
 		end
 
 		if "winphone81" == _OPTIONS["vs"] then
 			premake.vstudio.toolset = "v120_wp81"
 			platforms { "ARM" }
-			location (_buildDir .. "projects/" .. _ACTION .. "-winphone81")
+			location (path.join(_buildDir, "projects", _ACTION .. "-winphone81"))
 		end
 	elseif _ACTION == "xcode4" then
 
 		if "osx" == _OPTIONS["xcode"] then
 			premake.xcode.toolset = "macosx"
-			location (_buildDir .. "projects/" .. _ACTION .. "-osx")
+			location (path.join(_buildDir, "projects", _ACTION .. "-osx"))
 		end
 		if "ios" == _OPTIONS["xcode"] then
 			premake.xcode.toolset = "iphoneos"
-			location (_buildDir .. "projects/" .. _ACTION .. "-ios")
+			location (path.join(_buildDir, "projects", _ACTION .. "-ios"))
 		end
 	end
 
@@ -334,7 +334,7 @@ function toolchain(_buildDir, _libDir)
 		}
 
 	configuration { "vs*" }
-		includedirs { bxDir .. "include/compat/msvc" }
+		includedirs { path.join(bxDir, "include/compat/msvc") }
 		defines {
 			"WIN32",
 			"_WIN32",
@@ -355,28 +355,28 @@ function toolchain(_buildDir, _libDir)
 		}
 
 	configuration { "vs2008" }
-		includedirs { bxDir .. "include/compat/msvc/pre1600" }
+		includedirs { path.join(bxDir .. "include/compat/msvc/pre1600") }
 
 	configuration { "x32", "vs*" }
-		targetdir (_buildDir .. "win32_" .. _ACTION .. "/bin")
-		objdir (_buildDir .. "win32_" .. _ACTION .. "/obj")
+		targetdir (path.join(_buildDir, "win32_" .. _ACTION, "bin"))
+		objdir (path.join(_buildDir, "win32_" .. _ACTION, "obj"))
 		libdirs {
-			_libDir .. "lib/win32_" .. _ACTION,
+			path.join(_libDir, "lib/win32_" .. _ACTION),
 			"$(DXSDK_DIR)/lib/x86",
 		}
 
 	configuration { "x64", "vs*" }
 		defines { "_WIN64" }
-		targetdir (_buildDir .. "win64_" .. _ACTION .. "/bin")
-		objdir (_buildDir .. "win64_" .. _ACTION .. "/obj")
+		targetdir (path.join(_buildDir, "win64_" .. _ACTION, "/bin"))
+		objdir (path.join(_buildDir, "win64_" .. _ACTION, "obj"))
 		libdirs {
-			_libDir .. "lib/win64_" .. _ACTION,
+			path.join(_libDir, "lib/win64_" .. _ACTION),
 			"$(DXSDK_DIR)/lib/x64",
 		}
 
 	configuration { "ARM", "vs*" }
-		targetdir (_buildDir .. "arm_" .. _ACTION .. "/bin")
-		objdir (_buildDir .. "arm_" .. _ACTION .. "/obj")
+		targetdir (path.join(_buildDir, "arm_" .. _ACTION, "bin"))
+		objdir (path.join(_buildDir, "arm_" .. _ACTION, "obj"))
 
 	configuration { "vs*-clang" }
 		buildoptions {
@@ -384,12 +384,12 @@ function toolchain(_buildDir, _libDir)
 		}
 
 	configuration { "x32", "vs*-clang" }
-		targetdir (_buildDir .. "win32_" .. _ACTION .. "-clang/bin")
-		objdir (_buildDir .. "win32_" .. _ACTION .. "-clang/obj")
+		targetdir (path.join(_buildDir, "win32_" .. _ACTION, "-clang", "bin"))
+		objdir (path.join(_buildDir, "win32_" .. _ACTION, "-clang/obj"))
 
 	configuration { "x64", "vs*-clang" }
-		targetdir (_buildDir .. "win64_" .. _ACTION .. "-clang/bin")
-		objdir (_buildDir .. "win64_" .. _ACTION .. "-clang/obj")
+		targetdir (path.join(_buildDir, "win64_" .. _ACTION .. "-clang", "bin"))
+		objdir (path.join(_buildDir, "win64_" .. _ACTION .. "-clang", "obj"))
 
 	configuration { "winphone8*" }
 		removeflags {
@@ -399,7 +399,7 @@ function toolchain(_buildDir, _libDir)
 
 	configuration { "mingw-*" }
 		defines { "WIN32" }
-		includedirs { bxDir .. "include/compat/mingw" }
+		includedirs { path.join(bxDir, "include/compat/mingw") }
 		buildoptions {
 			"-std=c++11",
 			"-Wunused-value",
@@ -416,19 +416,19 @@ function toolchain(_buildDir, _libDir)
 		}
 
 	configuration { "x32", "mingw-gcc" }
-		targetdir (_buildDir .. "win32_mingw-gcc" .. "/bin")
-		objdir (_buildDir .. "win32_mingw-gcc" .. "/obj")
+		targetdir (path.join(_buildDir, "win32_mingw-gcc", "bin"))
+		objdir (path.join(_buildDir, "win32_mingw-gcc", "obj"))
 		libdirs {
-			_libDir .. "lib/win32_mingw-gcc",
+			path.join(_libDir, "lib/win32_mingw-gcc"),
 			"$(DXSDK_DIR)/lib/x86",
 		}
 		buildoptions { "-m32" }
 
 	configuration { "x64", "mingw-gcc" }
-		targetdir (_buildDir .. "win64_mingw-gcc" .. "/bin")
-		objdir (_buildDir .. "win64_mingw-gcc" .. "/obj")
+		targetdir (path.join(_buildDir, "win64_mingw-gcc", "bin"))
+		objdir (path.join(_buildDir, "win64_mingw-gcc", "obj"))
 		libdirs {
-			_libDir .. "lib/win64_mingw-gcc",
+			path.join(_libDir, "lib/win64_mingw-gcc"),
 			"$(DXSDK_DIR)/lib/x64",
 			"$(GLES_X64_DIR)",
 		}
@@ -446,19 +446,19 @@ function toolchain(_buildDir, _libDir)
 		}
 
 	configuration { "x32", "mingw-clang" }
-		targetdir (_buildDir .. "win32_mingw-clang" .. "/bin")
-		objdir (_buildDir .. "win32_mingw-clang" .. "/obj")
+		targetdir (path.join(_buildDir, "win32_mingw-clang", "bin"))
+		objdir (path.join(_buildDir, "win32_mingw-clang", "obj"))
 		libdirs {
-			_libDir .. "lib/win32_mingw-clang",
+			path.join(_libDir, "lib/win32_mingw-clang"),
 			"$(DXSDK_DIR)/lib/x86",
 		}
 		buildoptions { "-m32" }
 
 	configuration { "x64", "mingw-clang" }
-		targetdir (_buildDir .. "win64_mingw-clang" .. "/bin")
-		objdir (_buildDir .. "win64_mingw-clang" .. "/obj")
+		targetdir (path.join(_buildDir, "win64_mingw-clang", "bin"))
+		objdir (path.join(_buildDir, "win64_mingw-clang", "obj"))
 		libdirs {
-			_libDir .. "lib/win64_mingw-clang",
+			path.join(_libDir, "lib/win64_mingw-clang"),
 			"$(DXSDK_DIR)/lib/x64",
 			"$(GLES_X64_DIR)",
 		}
@@ -487,33 +487,33 @@ function toolchain(_buildDir, _libDir)
 		}
 
 	configuration { "linux-gcc", "x32" }
-		targetdir (_buildDir .. "linux32_gcc" .. "/bin")
-		objdir (_buildDir .. "linux32_gcc" .. "/obj")
-		libdirs { _libDir .. "lib/linux32_gcc" }
+		targetdir (path.join(_buildDir, "linux32_gcc", "bin"))
+		objdir (path.join(_buildDir, "linux32_gcc", "obj"))
+		libdirs { path.join(_libDir, "lib/linux32_gcc") }
 		buildoptions {
 			"-m32",
 		}
 
 	configuration { "linux-gcc", "x64" }
-		targetdir (_buildDir .. "linux64_gcc" .. "/bin")
-		objdir (_buildDir .. "linux64_gcc" .. "/obj")
-		libdirs { _libDir .. "lib/linux64_gcc" }
+		targetdir (path.join(_buildDir, "linux64_gcc", "bin"))
+		objdir (path.join(_buildDir, "linux64_gcc", "obj"))
+		libdirs { path.join(_libDir, "lib/linux64_gcc") }
 		buildoptions {
 			"-m64",
 		}
 
 	configuration { "linux-clang", "x32" }
-		targetdir (_buildDir .. "linux32_clang" .. "/bin")
-		objdir (_buildDir .. "linux32_clang" .. "/obj")
-		libdirs { _libDir .. "lib/linux32_clang" }
+		targetdir (path.join(_buildDir, "linux32_clang", "bin"))
+		objdir (path.join(_buildDir, "linux32_clang", "obj"))
+		libdirs { path.join(_libDir, "lib/linux32_clang") }
 		buildoptions {
 			"-m32",
 		}
 
 	configuration { "linux-clang", "x64" }
-		targetdir (_buildDir .. "linux64_clang" .. "/bin")
-		objdir (_buildDir .. "linux64_clang" .. "/obj")
-		libdirs { _libDir .. "lib/linux64_clang" }
+		targetdir (path.join(_buildDir, "linux64_clang", "bin"))
+		objdir (path.join(_buildDir, "linux64_clang", "obj"))
+		libdirs { path.join(_libDir, "lib/linux64_clang") }
 		buildoptions {
 			"-m64",
 		}
@@ -559,17 +559,17 @@ function toolchain(_buildDir, _libDir)
 		}
 
 	configuration { "android-arm" }
-		targetdir (_buildDir .. "android-arm" .. "/bin")
-		objdir (_buildDir .. "android-arm" .. "/obj")
+		targetdir (path.join(_buildDir, "android-arm", "bin"))
+		objdir (path.join(_buildDir, "android-arm", "obj"))
 		libdirs {
-			_libDir .. "lib/android-arm",
+			path.join(_libDir, "lib/android-arm"),
 			"$(ANDROID_NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a",
 		}
 		includedirs {
 			"$(ANDROID_NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/4.8/libs/armeabi-v7a/include",
 		}
 		buildoptions {
-			"--sysroot=$(ANDROID_NDK_ROOT)/platforms/" .. androidPlatform .. "/arch-arm",
+			"--sysroot=" .. path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "arch-arm"),
 			"-mthumb",
 			"-march=armv7-a",
 			"-mfloat-abi=softfp",
@@ -578,46 +578,46 @@ function toolchain(_buildDir, _libDir)
 			"-Wundef",
 		}
 		linkoptions {
-			"--sysroot=$(ANDROID_NDK_ROOT)/platforms/" .. androidPlatform .. "/arch-arm",
-			"$(ANDROID_NDK_ROOT)/platforms/" .. androidPlatform .. "/arch-arm/usr/lib/crtbegin_so.o",
-			"$(ANDROID_NDK_ROOT)/platforms/" .. androidPlatform .. "/arch-arm/usr/lib/crtend_so.o",
+			"--sysroot=" .. path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "arch-arm"),
+			path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "arch-arm/usr/lib/crtbegin_so.o"),
+			path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "arch-arm/usr/lib/crtend_so.o"),
 			"-march=armv7-a",
 			"-Wl,--fix-cortex-a8",
 		}
 
 	configuration { "android-mips" }
-		targetdir (_buildDir .. "android-mips" .. "/bin")
-		objdir (_buildDir .. "android-mips" .. "/obj")
+		targetdir (path.join(_buildDir, "android-mips", "bin"))
+		objdir (path.join(_buildDir, "android-mips", "obj"))
 		libdirs {
-			_libDir .. "lib/android-mips",
+			path.join(_libDir, "lib/android-mips"),
 			"$(ANDROID_NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/4.8/libs/mips",
 		}
 		includedirs {
 			"$(ANDROID_NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/4.8/libs/mips/include",
 		}
 		buildoptions {
-			"--sysroot=$(ANDROID_NDK_ROOT)/platforms/" .. androidPlatform .. "/arch-mips",
+			"--sysroot=" .. path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "arch-mips"),
 			"-Wunused-value",
 			"-Wundef",
 		}
 		linkoptions {
-			"--sysroot=$(ANDROID_NDK_ROOT)/platforms/" .. androidPlatform .. "/arch-mips",
-			"$(ANDROID_NDK_ROOT)/platforms/" .. androidPlatform .. "/arch-mips/usr/lib/crtbegin_so.o",
-			"$(ANDROID_NDK_ROOT)/platforms/" .. androidPlatform .. "/arch-mips/usr/lib/crtend_so.o",
+			"--sysroot=" .. path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "arch-mips"),
+			path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "arch-mips/usr/lib/crtbegin_so.o"),
+			path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "arch-mips/usr/lib/crtend_so.o"),
 		}
 
 	configuration { "android-x86" }
-		targetdir (_buildDir .. "android-x86" .. "/bin")
-		objdir (_buildDir .. "android-x86" .. "/obj")
+		targetdir (path.join(_buildDir, "android-x86", "bin"))
+		objdir (path.join(_buildDir, "android-x86", "obj"))
 		libdirs {
-			_libDir .. "lib/android-x86",
+			path.join(_libDir, "lib/android-x86"),
 			"$(ANDROID_NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/4.8/libs/x86",
 		}
 		includedirs {
 			"$(ANDROID_NDK_ROOT)/sources/cxx-stl/gnu-libstdc++/4.8/libs/x86/include",
 		}
 		buildoptions {
-			"--sysroot=$(ANDROID_NDK_ROOT)/platforms/" .. androidPlatform .. "/arch-x86",
+			"--sysroot=" .. path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "arch-x86"),
 			"-march=i686",
 			"-mtune=atom",
 			"-mstackrealign",
@@ -627,15 +627,15 @@ function toolchain(_buildDir, _libDir)
 			"-Wundef",
 		}
 		linkoptions {
-			"--sysroot=$(ANDROID_NDK_ROOT)/platforms/" .. androidPlatform .. "/arch-x86",
-			"$(ANDROID_NDK_ROOT)/platforms/" .. androidPlatform .. "/arch-x86/usr/lib/crtbegin_so.o",
-			"$(ANDROID_NDK_ROOT)/platforms/" .. androidPlatform .. "/arch-x86/usr/lib/crtend_so.o",
+			"--sysroot=" .. path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "arch-x86"),
+			path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "arch-x86/usr/lib/crtbegin_so.o"),
+			path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "/arch-x86/usr/lib/crtend_so.o"),
 		}
 
 	configuration { "asmjs" }
-		targetdir (_buildDir .. "asmjs" .. "/bin")
-		objdir (_buildDir .. "asmjs" .. "/obj")
-		libdirs { _libDir .. "lib/asmjs" }
+		targetdir (path.join(_buildDir, "asmjs", "bin"))
+		objdir (path.join(_buildDir, "asmjs", "obj"))
+		libdirs { path.join(_libDir, "lib/asmjs") }
 		buildoptions {
 			"-isystem$(EMSCRIPTEN)/system/include",
 			"-isystem$(EMSCRIPTEN)/system/include/libc",
@@ -644,11 +644,11 @@ function toolchain(_buildDir, _libDir)
 		}
 
 	configuration { "freebsd" }
-		targetdir (_buildDir .. "freebsd" .. "/bin")
-		objdir (_buildDir .. "freebsd" .. "/obj")
-		libdirs { _libDir .. "lib/freebsd" }
+		targetdir (path.join(_buildDir, "freebsd", "bin"))
+		objdir (path.join(_buildDir, "freebsd", "obj"))
+		libdirs { path.join(_libDir, "lib/freebsd") }
 		includedirs {
-			bxDir .. "include/compat/freebsd",
+			path.join(bxDir, "include/compat/freebsd"),
 		}
 
 	configuration { "nacl or nacl-arm or pnacl" }
@@ -664,7 +664,7 @@ function toolchain(_buildDir, _libDir)
 		}
 		includedirs {
 			"$(NACL_SDK_ROOT)/include",
-			bxDir .. "include/compat/nacl",
+			path.join(bxDir, "include/compat/nacl"),
 		}
 
 	configuration { "nacl" }
@@ -678,9 +678,9 @@ function toolchain(_buildDir, _libDir)
 		}
 
 	configuration { "x32", "nacl" }
-		targetdir (_buildDir .. "nacl-x86" .. "/bin")
-		objdir (_buildDir .. "nacl-x86" .. "/obj")
-		libdirs { _libDir .. "lib/nacl-x86" }
+		targetdir (path.join(_buildDir, "nacl-x86", "bin"))
+		objdir (path.join(_buildDir, "nacl-x86", "obj"))
+		libdirs { path.join(_libDir, "lib/nacl-x86") }
 		linkoptions { "-melf32_nacl" }
 
 	configuration { "x32", "nacl", "Debug" }
@@ -690,9 +690,9 @@ function toolchain(_buildDir, _libDir)
 		libdirs { "$(NACL_SDK_ROOT)/lib/newlib_x86_32/Release" }
 
 	configuration { "x64", "nacl" }
-		targetdir (_buildDir .. "nacl-x64" .. "/bin")
-		objdir (_buildDir .. "nacl-x64" .. "/obj")
-		libdirs { _libDir .. "lib/nacl-x64" }
+		targetdir (path.join(_buildDir, "nacl-x64", "bin"))
+		objdir (path.join(_buildDir, "nacl-x64", "obj"))
+		libdirs { path.join(_libDir, "lib/nacl-x64") }
 		linkoptions { "-melf64_nacl" }
 
 	configuration { "x64", "nacl", "Debug" }
@@ -705,9 +705,9 @@ function toolchain(_buildDir, _libDir)
 		buildoptions {
 			"-Wno-psabi", -- note: the mangling of 'va_list' has changed in GCC 4.4.0
 		}
-		targetdir (_buildDir .. "nacl-arm" .. "/bin")
-		objdir (_buildDir .. "nacl-arm" .. "/obj")
-		libdirs { _libDir .. "lib/nacl-arm" }
+		targetdir (path.join(_buildDir, "nacl-arm", "bin"))
+		objdir (path.join(_buildDir, "nacl-arm", "obj"))
+		libdirs { path.join(_libDir, "lib/nacl-arm") }
 
 	configuration { "nacl-arm", "Debug" }
 		libdirs { "$(NACL_SDK_ROOT)/lib/newlib_arm/Debug" }
@@ -716,9 +716,9 @@ function toolchain(_buildDir, _libDir)
 		libdirs { "$(NACL_SDK_ROOT)/lib/newlib_arm/Release" }
 
 	configuration { "pnacl" }
-		targetdir (_buildDir .. "pnacl" .. "/bin")
-		objdir (_buildDir .. "pnacl" .. "/obj")
-		libdirs { _libDir .. "lib/pnacl" }
+		targetdir (path.join(_buildDir, "pnacl", "bin"))
+		objdir (path.join(_buildDir, "pnacl", "obj"))
+		libdirs { path.join(_libDir, "lib/pnacl") }
 
 	configuration { "pnacl", "Debug" }
 		libdirs { "$(NACL_SDK_ROOT)/lib/pnacl/Debug" }
@@ -727,27 +727,27 @@ function toolchain(_buildDir, _libDir)
 		libdirs { "$(NACL_SDK_ROOT)/lib/pnacl/Release" }
 
 	configuration { "Xbox360" }
-		targetdir (_buildDir .. "xbox360" .. "/bin")
-		objdir (_buildDir .. "xbox360" .. "/obj")
-		includedirs { bxDir .. "include/compat/msvc" }
-		libdirs { _libDir .. "lib/xbox360" }
+		targetdir (path.join(_buildDir, "xbox360", "bin"))
+		objdir (path.join(_buildDir, "xbox360", "obj"))
+		includedirs { path.join(bxDir, "include/compat/msvc") }
+		libdirs { path.join(_libDir, "lib/xbox360") }
 		defines {
 			"NOMINMAX",
 			"_XBOX",
 		}
 
 	configuration { "osx", "x32" }
-		targetdir (_buildDir .. "osx32_clang" .. "/bin")
-		objdir (_buildDir .. "osx32_clang" .. "/obj")
-		libdirs { _libDir .. "lib/osx32_clang" }
+		targetdir (path.join(_buildDir, "osx32_clang", "bin"))
+		objdir (path.join(_buildDir, "osx32_clang", "obj"))
+		libdirs { path.join(_libDir, "lib/osx32_clang") }
 		buildoptions {
 			"-m32",
 		}
 
 	configuration { "osx", "x64" }
-		targetdir (_buildDir .. "osx64_clang" .. "/bin")
-		objdir (_buildDir .. "osx64_clang" .. "/obj")
-		libdirs { _libDir .. "lib/osx64_clang" }
+		targetdir (path.join(_buildDir, "osx64_clang", "bin"))
+		objdir (path.join(_buildDir, "osx64_clang", "obj"))
+		libdirs { path.join(_libDir, "lib/osx64_clang") }
 		buildoptions {
 			"-m64",
 		}
@@ -759,7 +759,7 @@ function toolchain(_buildDir, _libDir)
 			"-Wunused-value",
 			"-Wundef",
 		}
-		includedirs { bxDir .. "include/compat/osx" }
+		includedirs { path.join(bxDir, "include/compat/osx") }
 
 	configuration { "ios*" }
 		linkoptions {
@@ -770,12 +770,12 @@ function toolchain(_buildDir, _libDir)
 			"-Wunused-value",
 			"-Wundef",
 		}
-		includedirs { bxDir .. "include/compat/ios" }
+		includedirs { path.join(bxDir, "include/compat/ios") }
 
 	configuration { "ios-arm" }
-		targetdir (_buildDir .. "ios-arm" .. "/bin")
-		objdir (_buildDir .. "ios-arm" .. "/obj")
-		libdirs { _libDir .. "lib/ios-arm" }
+		targetdir (path.join(_buildDir, "ios-arm", "bin"))
+		objdir (path.join(_buildDir, "ios-arm", "obj"))
+		libdirs { path.join(_libDir, "lib/ios-arm") }
 		linkoptions {
 			"-miphoneos-version-min=7.0",
 			"-arch armv7",
@@ -791,9 +791,9 @@ function toolchain(_buildDir, _libDir)
 		}
 
 	configuration { "ios-simulator" }
-		targetdir (_buildDir .. "ios-simulator" .. "/bin")
-		objdir (_buildDir .. "ios-simulator" .. "/obj")
-		libdirs { _libDir .. "lib/ios-simulator" }
+		targetdir (path.join(_buildDir, "ios-simulator", "bin"))
+		objdir (path.join(_buildDir, "ios-simulator", "obj"))
+		libdirs { path.join(_libDir, "lib/ios-simulator") }
 		linkoptions {
 			"-mios-simulator-version-min=7.0",
 			"-arch i386",
@@ -809,10 +809,10 @@ function toolchain(_buildDir, _libDir)
 		}
 
 	configuration { "qnx-arm" }
-		targetdir (_buildDir .. "qnx-arm" .. "/bin")
-		objdir (_buildDir .. "qnx-arm" .. "/obj")
-		libdirs { _libDir .. "lib/qnx-arm" }
---		includedirs { bxDir .. "include/compat/qnx" }
+		targetdir (path.join(_buildDir, "qnx-arm", "bin"))
+		objdir (path.join(_buildDir, "qnx-arm", "obj"))
+		libdirs { path.join(_libDir, "lib/qnx-arm") }
+--		includedirs { path.join(bxDir, "include/compat/qnx") }
 		buildoptions {
 			"-std=c++0x",
 			"-Wno-psabi", -- note: the mangling of 'va_list' has changed in GCC 4.4.0
@@ -821,10 +821,10 @@ function toolchain(_buildDir, _libDir)
 		}
 
 	configuration { "rpi" }
-		targetdir (_buildDir .. "rpi" .. "/bin")
-		objdir (_buildDir .. "rpi" .. "/obj")
+		targetdir (path.join(_buildDir, "rpi", "bin"))
+		objdir (path.join(_buildDir, "rpi", "obj"))
 		libdirs {
-			_libDir .. "lib/rpi",
+			path.join(_libDir, "lib/rpi"),
 			"/opt/vc/lib",
 		}
 		defines {


### PR DESCRIPTION
Using path.join instead of string concatenation makes the scripts more
OS-neutral. It also protects against missing or doubled "/" characters
in paths.