### PR TITLE
Attempt to add -g option to gcc and clang builds to include debug symbols

### DIFF
--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -421,6 +421,7 @@ function toolchain(_buildDir, _libDir)
 			"-msse2",
 			"-Wunused-value",
 			"-Wundef",
+			"-g",
 		}
 		linkoptions {
 			"-Wl,--gc-sections",
@@ -490,6 +491,7 @@ function toolchain(_buildDir, _libDir)
 			"-msse2",
 			"-Wunused-value",
 			"-Wundef",
+			"-g",
 		}
 		links {
 			"rt",
@@ -674,6 +676,7 @@ function toolchain(_buildDir, _libDir)
 			"-ffunction-sections",
 			"-Wunused-value",
 			"-Wundef",
+			"-g",
 		}
 		includedirs {
 			"$(NACL_SDK_ROOT)/include",
@@ -771,6 +774,7 @@ function toolchain(_buildDir, _libDir)
 			"-msse2",
 			"-Wunused-value",
 			"-Wundef",
+			"-g",
 		}
 		includedirs { path.join(bxDir, "include/compat/osx") }
 
@@ -782,6 +786,7 @@ function toolchain(_buildDir, _libDir)
 			"-Wfatal-errors",
 			"-Wunused-value",
 			"-Wundef",
+			"-g",
 		}
 		includedirs { path.join(bxDir, "include/compat/ios") }
 
@@ -848,6 +853,7 @@ function toolchain(_buildDir, _libDir)
 			"-std=c++0x",
 			"-Wunused-value",
 			"-Wundef",
+			"-g",
 		}
 		includedirs {
 			"/opt/vc/include",


### PR DESCRIPTION
libbgfxDebug.a doesn't seem to include debug information, which complicates things when debugging.

I don't really understand genie, or the organisation of the build system, but I tried adding the -g flag to gcc and clang based builds to include symbols properly. Might want to make sure I got it right though if you want to include this fix.