### PR TITLE
Fix for xcode target build directory

### DIFF
--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -813,6 +813,10 @@ function toolchain(_buildDir, _libDir)
 			"-m64",
 		}
 
+	configuration { "osx", "Universal" }
+		targetdir (path.join(_buildDir, "osx_universal/bin"))
+		objdir (path.join(_buildDir, "osx_universal/bin"))
+
 	configuration { "osx" }
 		buildoptions {
 			"-Wfatal-errors",


### PR DESCRIPTION
I found that the genie.lua that's currently in bgfx sets the xcode4 solution to "universal", and the toolchain.lua didn't have a configuration that matched "osx" and "universal" so I added one and set the targetdir in it.