### PR TITLE
Use __EMSCRIPTEN__ rather than EMSCRIPTEN.

### DIFF
--- a/include/bx/platform.h
+++ b/include/bx/platform.h
@@ -175,7 +175,7 @@
 #elif defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__)
 #	undef  BX_PLATFORM_OSX
 #	define BX_PLATFORM_OSX 1
-#elif defined(EMSCRIPTEN)
+#elif defined(__EMSCRIPTEN__)
 #	undef  BX_PLATFORM_EMSCRIPTEN
 #	define BX_PLATFORM_EMSCRIPTEN 1
 #elif defined(__ORBIS__)


### PR DESCRIPTION
I'm hoping that one day, we can consider ``EMSCRIPTEN`` to be deprecated and perhaps even to remove it.
