### PR TITLE
Restore support for OSX 10.7 "Lion" and earlier

### DIFF
--- a/include/bx/macros.h
+++ b/include/bx/macros.h
@@ -75,7 +75,7 @@
 #	if BX_CLANG_HAS_FEATURE(cxx_thread_local)
 #		define BX_THREAD_LOCAL __thread
 #	endif // BX_COMPILER_CLANG
-#	if BX_COMPILER_GCC >= 40200
+#	if (!BX_PLATFORM_OSX && (BX_COMPILER_GCC >= 40200)) || (BX_COMPILER_GCC >= 40500)
 #		define BX_THREAD_LOCAL __thread
 #	endif // BX_COMPILER_GCC
 #	define BX_ATTRIBUTE(_x) __attribute__( (_x) )

--- a/include/bx/os.h
+++ b/include/bx/os.h
@@ -133,14 +133,25 @@ namespace bx
 			: 0
 			;
 #elif BX_PLATFORM_OSX
+#ifdef MACH_TASK_BASIC_INFO
 		mach_task_basic_info info;
 		mach_msg_type_number_t infoCount = MACH_TASK_BASIC_INFO_COUNT;
 
-		int result = task_info(mach_task_self()
+		int const result = task_info(mach_task_self()
 				, MACH_TASK_BASIC_INFO
 				, (task_info_t)&info
 				, &infoCount
 				);
+#else // MACH_TASK_BASIC_INFO
+		task_basic_info info;
+		mach_msg_type_number_t infoCount = TASK_BASIC_INFO_COUNT;
+
+		int const result = task_info(mach_task_self()
+				, TASK_BASIC_INFO
+				, (task_info_t)&info
+				, &infoCount
+				);
+#endif // MACH_TASK_BASIC_INFO
 		if (KERN_SUCCESS != result)
 		{
 			return 0;


### PR DESCRIPTION
Very simple changes to allow building bx/bgfx at least as far back as 10.6.8 "Snow Leopard".  Some Mach APIs are slightly different on older OSX, and GCC doesn't support __thread qualifier on OSX before version 4.5.