### PR TITLE
Replaces $ variable name with lock

### DIFF
--- a/include/bx/mpscqueue.h
+++ b/include/bx/mpscqueue.h
@@ -29,7 +29,7 @@ namespace bx
 
 		void push(Ty* _ptr) // producer only
 		{
-			LwMutexScope $(m_write);
+			LwMutexScope lock(m_write);
 			m_queue.push(_ptr);
 		}
 


### PR DESCRIPTION
Warns at level 4, seemed nicer to follow spscqueue.h