### PR TITLE
Fixing android-x86 build

### DIFF
--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -800,7 +800,7 @@ function toolchain(_buildDir, _libDir)
 		linkoptions {
 			"--sysroot=" .. path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "arch-x86"),
 			path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "arch-x86/usr/lib/crtbegin_so.o"),
-			path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "/arch-x86/usr/lib/crtend_so.o"),
+			path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "arch-x86/usr/lib/crtend_so.o"),
 		}
 
 	configuration { "asmjs" }


### PR DESCRIPTION
Error was: 'i686-linux-android-g++: error: /arch-x86/usr/lib/crtend_so.o: No such file or directory'