### PR TITLE
Android application default name not valid

### DIFF
--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -664,6 +664,7 @@ function toolchain(_buildDir, _libDir)
 		}
 
 	configuration { "android-*" }
+		targetprefix ("lib")
 		flags {
 			"NoImportLib",
 		}


### PR DESCRIPTION
Android generated application are provided as a dynamic library.
To be loaded flawlessly by 'NativeActivity' class, they must have 'lib' as prefix and '.so' as extension (see 'AndroidManifest.xml' section at 'developer.android.com/ndk/samples/sample_na.html').
This adds automatically the 'lib' prefix to the generated library.