### PR TITLE
Include FreeBSD-specific header only on FreeBSD.

### DIFF
--- a/include/bx/thread.h
+++ b/include/bx/thread.h
@@ -8,7 +8,7 @@
 
 #if BX_PLATFORM_POSIX
 #	include <pthread.h>
-#	if BX_PLATFORM_BSD
+#	if defined(__FreeBSD__)
 #		include <pthread_np.h>
 #	endif
 #	if defined(__GLIBC__) && !( (__GLIBC__ > 2) || ( (__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12) ) )


### PR DESCRIPTION
````
commit 74e9c84a597b183378b9b0e0fe9659301628a282
Author: Libor Capak <capak@inputwish.com>
Date:   Wed May 25 19:58:07 2016 +0200

    fix freebsd
````
broke the build on NetBSD, this patch fixes it.