### PR TITLE
GNU/kFreeBSD support

### DIFF
--- a/include/bx/thread.h
+++ b/include/bx/thread.h
@@ -11,9 +11,9 @@
 #	if defined(__FreeBSD__)
 #		include <pthread_np.h>
 #	endif
-#	if defined(__GLIBC__) && !( (__GLIBC__ > 2) || ( (__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12) ) )
+#	if defined(__linux__) && (BX_CRT_GLIBC < 21200)
 #		include <sys/prctl.h>
-#	endif // defined(__GLIBC__) ...
+#	endif
 #elif BX_PLATFORM_WINRT
 using namespace Platform;
 using namespace Windows::Foundation;
@@ -157,12 +157,10 @@ namespace bx
 		{
 #if BX_PLATFORM_OSX || BX_PLATFORM_IOS
 			pthread_setname_np(_name);
-#elif BX_PLATFORM_LINUX
-#	if defined(__GLIBC__) && (__GLIBC__ > 2) || ( (__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 12) )
+#elif (BX_CRT_GLIBC >= 21200)
 			pthread_setname_np(m_handle, _name);
-#	else
+#elif BX_PLATFORM_LINUX
 			prctl(PR_SET_NAME,_name, 0, 0, 0);
-#	endif // defined(__GLIBC__) ...
 #elif BX_PLATFORM_BSD
 #ifdef __NetBSD__
 			pthread_setname_np(m_handle, "%s", (void *)_name);

--- a/include/compat/freebsd/alloca.h
+++ b/include/compat/freebsd/alloca.h
@@ -1,1 +1,5 @@
+#if BX_CRT_GLIBC
+#include_next <alloca.h>
+#else
 #include <stdlib.h>
+#endif

--- a/include/compat/freebsd/signal.h
+++ b/include/compat/freebsd/signal.h
@@ -1,1 +1,5 @@
+#ifdef BX_CRT_GLIBC
+#include_next <signal.h>
+#else
 #include <sys/signal.h>
+#endif


### PR DESCRIPTION
Hi again,

I have re-based this for the new BX_CRT_GLIBC macro, which is actually quite neat (thanks).

On GNU/kFreeBSD, where we have GNU libc, we must use the system-provided alloca.h and signal.h, instead of wrapping FreeBSD libc headers we don't have.

And with sufficiently new GNU libc (>= 2.12) we do not need any other headers than pthread.h, in order to use pthread_setname_np.  In any other case (older GNU libc, or any other libc), fall back to Linux, FreeBSD or other platform-specific alternatives.