### PR TITLE
Update toolchain.lua

### DIFF
--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -907,7 +907,6 @@ function toolchain(_buildDir, _libDir)
 		libdirs { path.join(_libDir, "lib/asmjs") }
 		buildoptions {
 			"-i\"system$(EMSCRIPTEN)/system/include\"",
-			"-i\"system$(EMSCRIPTEN)/system/include/libc\"",
 			"-Wunused-value",
 			"-Wundef",
 		}


### PR DESCRIPTION
I got an error: /usr/lib/emscripten/system/include/libcxx/cstddef:43:15: fatal error: 'stddef.h' file not found

removing this line, fixes it. 

I'm not quite shure why this is so.

find $EMSCRIPTEN -name stddef.h 
/usr/lib/emscripten/system/include/libcxx/stddef.h
/usr/lib/emscripten/system/include/libc/stddef.h