### PR TITLE
fix strncmp bug

### DIFF
--- a/src/string.cpp
+++ b/src/string.cpp
@@ -73,8 +73,8 @@ namespace bx
 			; ++_lhs, ++_rhs, --_max
 			)
 		{
-			if (*_lhs != '\0'
-			||  *_rhs != '\0')
+			if (*_lhs == '\0'
+			||  *_rhs == '\0')
 			{
 				break;
 			}


### PR DESCRIPTION
It seems like this is correct.
The strncmp function did not compare to the end of the string.