### PR TITLE
Permit BX_CRT_MUSL to be pre-defined

### DIFF
--- a/include/bx/platform.h
+++ b/include/bx/platform.h
@@ -34,7 +34,9 @@
 #define BX_CRT_LIBCXX 0
 #define BX_CRT_MINGW  0
 #define BX_CRT_MSVC   0
-#define BX_CRT_MUSL   0
+#ifndef BX_CRT_MUSL
+#	define BX_CRT_MUSL   0
+#endif
 #define BX_CRT_NEWLIB 0
 
 #ifndef BX_CRT_NONE


### PR DESCRIPTION
related to #142 

I could wrap all the others as well if you prefer, but this does the trick for me.