### PR TITLE
assume LLVM libc++ if __llvm__ is defined but __GLIBC__ is undefined

### DIFF
--- a/include/bx/platform.h
+++ b/include/bx/platform.h
@@ -239,7 +239,7 @@
 #	elif defined(__MINGW32__) || defined(__MINGW64__)
 #		undef  BX_CRT_MINGW
 #		define BX_CRT_MINGW 1
-#	elif defined(__apple_build_version__) || defined(__ORBIS__) || defined(__EMSCRIPTEN__)
+#	elif defined(__apple_build_version__) || defined(__ORBIS__) || defined(__EMSCRIPTEN__) || defined(__llvm__)
 #		undef  BX_CRT_LIBCXX
 #		define BX_CRT_LIBCXX 1
 #	endif //


### PR DESCRIPTION
This fixes build with MacPorts or self-built clang on OSX, and on *BSD without GNU runtime libraries present.