### PR TITLE
Use system log2f in bx::flog2 implementation. Fixes incorrect result …

### DIFF
--- a/include/bx/inline/fpumath.inl
+++ b/include/bx/inline/fpumath.inl
@@ -136,11 +136,6 @@ namespace bx
 		return fpow(2.0f, _a);
 	}
 
-	inline float flog2(float _a)
-	{
-		return flog(_a) * 1.442695041f;
-	}
-
 	inline float frsqrt(float _a)
 	{
 		return 1.0f/fsqrt(_a);

--- a/src/fpumath.cpp
+++ b/src/fpumath.cpp
@@ -63,6 +63,11 @@ namespace bx
 		return ::logf(_a);
 	}
 
+	float flog2(float _a)
+	{
+		return ::logf(_a) * (1 / ::logf(2));
+	}
+
 	float fsqrt(float _a)
 	{
 		return ::sqrtf(_a);


### PR DESCRIPTION
…when compiled to asm.js. E.g. bx::flog2(256) gives 7.9999998932 instead of 8.0. This breaks mipmap calculations in bgfx.

edit: log2f not available on all platforms. Multiplying by 1/logf(2) instead.