### PR TITLE
fix error C2733: "second C linkage of overloaded function not allowed"

### DIFF
--- a/src/filepath.cpp
+++ b/src/filepath.cpp
@@ -8,7 +8,7 @@
 #include <bx/readerwriter.h>
 
 #if BX_PLATFORM_WINDOWS
-extern "C" __declspec(dllimport) uint32_t __stdcall GetTempPathA(uint32_t _max, char* _ptr);
+extern "C" __declspec(dllimport) unsigned long __stdcall GetTempPathA(unsigned long _max, char* _ptr);
 #endif // BX_PLATFORM_WINDOWS
 
 namespace bx


### PR DESCRIPTION
I consistently get the error "second C linkage of overloaded function not allowed".  Changing uint32_t to unsigned long to make the function declaration match it's original fixes this issue for me.