### PR TITLE
Support for the NX platform

### DIFF
--- a/include/bx/platform.h
+++ b/include/bx/platform.h
@@ -59,6 +59,7 @@
 #define BX_PLATFORM_WINDOWS    0
 #define BX_PLATFORM_WINRT      0
 #define BX_PLATFORM_XBOXONE    0
+#define BX_PLATFORM_NX         0
 
 // http://sourceforge.net/apps/mediawiki/predef/index.php?title=Compilers
 #if defined(__clang__)
@@ -213,6 +214,9 @@
 #elif defined(__GNU__)
 #	undef  BX_PLATFORM_HURD
 #	define BX_PLATFORM_HURD 1
+#elif defined(__NX__)
+# undef BX_PLATFORM_NX
+# define BX_PLATFORM_NX 1
 #endif //
 
 #if !BX_CRT_NONE
@@ -258,6 +262,7 @@
 		|| BX_PLATFORM_STEAMLINK  \
 		|| BX_PLATFORM_PS4        \
 		|| BX_PLATFORM_RPI        \
+		|| BX_PLATFORM_NX         \
 		)
 
 #define BX_PLATFORM_NONE !(0      \

--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -547,7 +547,7 @@ function toolchain(_buildDir, _libDir)
 			"EnableSSE2",
 		}
 
-	configuration { "vs*", "not orbis" }
+	configuration { "vs*", "not orbis", "not NX32", "not NX64" }
 		includedirs { path.join(bxDir, "include/compat/msvc") }
 		defines {
 			"WIN32",

--- a/src/os.cpp
+++ b/src/os.cpp
@@ -23,7 +23,8 @@
 	|| BX_PLATFORM_OSX        \
 	|| BX_PLATFORM_PS4        \
 	|| BX_PLATFORM_RPI        \
-	|| BX_PLATFORM_STEAMLINK
+	|| BX_PLATFORM_STEAMLINK  \
+	|| BX_PLATFORM_NX
 #	include <sched.h> // sched_yield
 #	if BX_PLATFORM_BSD  \
 	|| BX_PLATFORM_IOS  \


### PR DESCRIPTION
This adds minimal support for the NX platform.

The target names in `toolchain.lua` is what the SDK needs the targets to be called, as far as I can tell, so it needs to exclude any Windows defines there.