### PR TITLE
mkdir takes only one argument in mingw

### DIFF
--- a/src/filepath.cpp
+++ b/src/filepath.cpp
@@ -395,6 +395,8 @@ namespace bx
 
 #if BX_CRT_MSVC
 		int32_t result = ::_mkdir(_filePath.get() );
+#elif BX_PLATFORM_WINDOWS
+		int32_t result = ::mkdir(_filePath.get());
 #else
 		int32_t result = ::mkdir(_filePath.get(), 0700);
 #endif // BX_CRT_MSVC


### PR DESCRIPTION
See:
https://stackoverflow.com/questions/12102147/too-many-arguments-to-function-int-mkdirconst-char
https://sourceforge.net/p/mingw-w64/mailman/message/35716445/
