### PR TITLE
Fix FreeBSD build

### DIFF
--- a/include/bx/bx.h
+++ b/include/bx/bx.h
@@ -6,10 +6,12 @@
 #ifndef BX_H_HEADER_GUARD
 #define BX_H_HEADER_GUARD
 
+#ifdef BX_PLATFORM_WINDOWS
 #include <alloca.h> // alloca
+#endif
 #include <stdarg.h> // va_list
 #include <stdint.h> // uint32_t
-#include <stdlib.h> // size_t
+#include <stdlib.h> // size_t, alloca
 #include <stddef.h> // ptrdiff_t
 
 #include "platform.h"

--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -6,7 +6,7 @@
 #include "bx_p.h"
 #include <bx/allocator.h>
 
-#include <malloc.h>
+#include <stdlib.h>
 
 #ifndef BX_CONFIG_ALLOCATOR_NATURAL_ALIGNMENT
 #	define BX_CONFIG_ALLOCATOR_NATURAL_ALIGNMENT 8

--- a/src/mutex.cpp
+++ b/src/mutex.cpp
@@ -13,6 +13,7 @@
 #	include "crt0.h"
 #elif  BX_PLATFORM_ANDROID \
 	|| BX_PLATFORM_LINUX   \
+	|| BX_PLATFORM_BSD     \
 	|| BX_PLATFORM_IOS     \
 	|| BX_PLATFORM_OSX     \
 	|| BX_PLATFORM_PS4     \

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -12,6 +12,7 @@
 #	include "crt0.h"
 #elif  BX_PLATFORM_ANDROID \
 	|| BX_PLATFORM_LINUX   \
+	|| BX_PLATFORM_BSD     \
 	|| BX_PLATFORM_IOS     \
 	|| BX_PLATFORM_OSX     \
 	|| BX_PLATFORM_PS4     \


### PR DESCRIPTION
- Add a couple forgotten `BX_PLATFORM_BSD`
- Use stdlib.h instead of deprecated malloc.h/alloca.h (that `#error` on FreeBSD 12)

More info about deprecated alloc headers: https://stackoverflow.com/a/12973361