### PR TITLE
Fix warning -Wgnu-zero-variadic-macro-arguments

### DIFF
--- a/include/bx/macros.h
+++ b/include/bx/macros.h
@@ -19,7 +19,7 @@
 #	define BX_VA_ARGS_PASS(...) (__VA_ARGS__)
 #endif // BX_COMPILER_MSVC
 
-#define BX_VA_ARGS_COUNT(...) BX_VA_ARGS_COUNT_ BX_VA_ARGS_PASS(__VA_ARGS__, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+#define BX_VA_ARGS_COUNT(...) BX_VA_ARGS_COUNT_ BX_VA_ARGS_PASS(__VA_ARGS__, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
 #define BX_VA_ARGS_COUNT_(_a1, _a2, _a3, _a4, _a5, _a6, _a7, _a8, _a9, _a10, _a11, _a12, _a13, _a14, _a15, _a16, _last, ...) _last
 
 ///


### PR DESCRIPTION
The c++11 standards forbids passing zero arguments to a variadic parameter, though it is accepted by most compilers it is generating a warning under clang.
Adding a 0 doesn't change the behaviour of the macro and makes sure an argument is passed for the variadic parameter in the case of only one parameter being passed to `BX_VA_ARGS_COUNT` (I had it triggered with `BX_UNUSED`)
