### PR TITLE
Fix linux-clang warning flags

### DIFF
--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -729,7 +729,6 @@ function toolchain(_buildDir, _libDir)
 --			"-Wduplicated-branches",
 --			"-Wduplicated-cond",
 --			"-Wjump-misses-init",
-			"-Wlogical-op",
 			"-Wshadow",
 --			"-Wnull-dereference",
 			"-Wunused-value",
@@ -746,6 +745,11 @@ function toolchain(_buildDir, _libDir)
 		linkoptions {
 			"-Wl,--gc-sections",
 			"-Wl,--as-needed",
+		}
+
+	configuration { "linux-gcc*" }
+		buildoptions {
+			"-Wlogical-op",
 		}
 
 	configuration { "linux-gcc*", "x32" }


### PR DESCRIPTION
`-Wlogical-op` does not exist when building using `linux-clang` and all similar warnings have been enabled by default. If treat all warnings as errors has been enabled, the build will fail due to thousands of unknown argument errors.

See: https://clang.llvm.org/docs/DiagnosticsReference.html