### PR TITLE
bx.h: include time.h for time_t typedef (musl libc)

### DIFF
--- a/include/bx/bx.h
+++ b/include/bx/bx.h
@@ -11,6 +11,7 @@
 #include <stdint.h> // uint32_t
 #include <stdlib.h> // size_t
 #include <stddef.h> // ptrdiff_t
+#include <time.h>   // time_t
 
 #include "platform.h"
 #include "config.h"


### PR DESCRIPTION
This is a tiny patch we need for Void Linux w/ Musl libc to build `bx` as part of `mame`. For glibc the `time_t` typedef seems to be pulled in by other includes while for Musl libc it is not. `time_t` is used in `src/crtnone.cpp` and `src/os.cpp`.