### PR TITLE
Android includes orders

### DIFF
--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -815,8 +815,8 @@ function toolchain(_buildDir, _libDir)
 			"NoImportLib",
 		}
 		includedirs {
-			"${ANDROID_NDK_ROOT}/sysroot/usr/include",
 			"$(ANDROID_NDK_ROOT)/sources/cxx-stl/llvm-libc++/include",
+			"${ANDROID_NDK_ROOT}/sysroot/usr/include",
 			"$(ANDROID_NDK_ROOT)/sources/android/native_app_glue",
 		}
 		linkoptions {


### PR DESCRIPTION
On android, sysroot includes must be after llvm includes, otherwise some includes, like `<cmath>` for example, throws compilations errors (some llvm builtins functions are not found).