### PR TITLE
Support little-endian PowerPC systems

### DIFF
--- a/include/bx/platform.h
+++ b/include/bx/platform.h
@@ -133,8 +133,14 @@
 #endif //
 
 #if BX_CPU_PPC
-#	undef  BX_CPU_ENDIAN_BIG
-#	define BX_CPU_ENDIAN_BIG 1
+// _LITTLE_ENDIAN exists on ppc64le.
+#	if _LITTLE_ENDIAN
+#		undef  BX_CPU_ENDIAN_LITTLE
+#		define BX_CPU_ENDIAN_LITTLE 1
+#	else
+#		undef  BX_CPU_ENDIAN_BIG
+#		define BX_CPU_ENDIAN_BIG 1
+#	endif
 #else
 #	undef  BX_CPU_ENDIAN_LITTLE
 #	define BX_CPU_ENDIAN_LITTLE 1


### PR DESCRIPTION
This resolves a compilation error that occurs on ppc64le systems such as the Raptor Talos II (see https://github.com/mamedev/mame/pull/4409 where it was requested to be upstreamed first).