### PR TITLE
call SetThreadDescription() to set thread name if available

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -248,9 +248,9 @@ namespace bx
 		// Try to use the new thread naming API from Win10 Creators update onwards if we have it
 		typedef HRESULT (WINAPI *SetThreadDescriptionProc)(HANDLE, PCWSTR);
 		SetThreadDescriptionProc SetThreadDescription = (SetThreadDescriptionProc)(GetProcAddress(GetModuleHandle(L"Kernel32.dll"), "SetThreadDescription"));
-		if ( SetThreadDescription )
+		if (SetThreadDescription)
 		{
-			uint32_t length = (uint32_t)bx::strnlen(_name) + 1;
+			uint32_t length = (uint32_t)bx::strnlen(_name)+1;
 			uint32_t size = length*sizeof(wchar_t);
 			wchar_t* name = (wchar_t*)alloca(size);
 			mbstowcs(name, _name, size-2);

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -8,6 +8,10 @@
 
 #if BX_CONFIG_SUPPORTS_THREADING
 
+#if BX_PLATFORM_WINDOWS && !BX_CRT_NONE
+#	include <bx/string.h>
+#endif
+
 #if BX_CRT_NONE
 #	include "crt0.h"
 #elif  BX_PLATFORM_ANDROID \
@@ -240,33 +244,46 @@ namespace bx
 #	else
 		pthread_set_name_np(ti->m_handle, _name);
 #	endif // defined(__NetBSD__)
-#elif BX_PLATFORM_WINDOWS && BX_COMPILER_MSVC
-#	pragma pack(push, 8)
-		struct ThreadName
+#elif BX_PLATFORM_WINDOWS
+		// Try to use the new thread naming API from Win10 Creators update onwards if we have it
+		typedef HRESULT (WINAPI *SetThreadDescriptionProc)(HANDLE, PCWSTR);
+		SetThreadDescriptionProc SetThreadDescription = (SetThreadDescriptionProc)(GetProcAddress(GetModuleHandle(L"Kernel32.dll"), "SetThreadDescription"));
+		if ( SetThreadDescription )
 		{
-			DWORD  type;
-			LPCSTR name;
-			DWORD  id;
-			DWORD  flags;
-		};
-#	pragma pack(pop)
-		ThreadName tn;
-		tn.type  = 0x1000;
-		tn.name  = _name;
-		tn.id    = ti->m_threadId;
-		tn.flags = 0;
+			uint32_t length = (uint32_t)bx::strnlen(_name) + 1;
+			uint32_t size = length*sizeof( wchar_t );
+			wchar_t* name = (wchar_t*)alloca(size);
+			mbstowcs(name, _name, size-2);
+			SetThreadDescription(ti->m_handle, name);
+		}
+#	if BX_COMPILER_MSVC
+#		pragma pack(push, 8)
+			struct ThreadName
+			{
+				DWORD  type;
+				LPCSTR name;
+				DWORD  id;
+				DWORD  flags;
+			};
+#		pragma pack(pop)
+			ThreadName tn;
+			tn.type  = 0x1000;
+			tn.name  = _name;
+			tn.id    = ti->m_threadId;
+			tn.flags = 0;
 
-		__try
-		{
-			RaiseException(0x406d1388
-					, 0
-					, sizeof(tn)/4
-					, reinterpret_cast<ULONG_PTR*>(&tn)
-					);
-		}
-		__except(EXCEPTION_EXECUTE_HANDLER)
-		{
-		}
+			__try
+			{
+				RaiseException(0x406d1388
+						, 0
+						, sizeof(tn)/4
+						, reinterpret_cast<ULONG_PTR*>(&tn)
+						);
+			}
+			__except(EXCEPTION_EXECUTE_HANDLER)
+			{
+			}
+#	endif // BX_COMPILER_MSVC
 #else
 		BX_UNUSED(_name);
 #endif // BX_PLATFORM_

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -245,7 +245,6 @@ namespace bx
 		pthread_set_name_np(ti->m_handle, _name);
 #	endif // defined(__NetBSD__)
 #elif BX_PLATFORM_WINDOWS
-#	if !BX_CRT_NONE
 		// Try to use the new thread naming API from Win10 Creators update onwards if we have it
 		typedef HRESULT (WINAPI *SetThreadDescriptionProc)(HANDLE, PCWSTR);
 		SetThreadDescriptionProc SetThreadDescription = (SetThreadDescriptionProc)(GetProcAddress(GetModuleHandle(TEXT("Kernel32.dll")), "SetThreadDescription"));
@@ -257,7 +256,6 @@ namespace bx
 			mbstowcs(name, _name, size-2);
 			SetThreadDescription(ti->m_handle, name);
 		}
-#	endif // BX_CRT_NONE	
 #	if BX_COMPILER_MSVC
 #		pragma pack(push, 8)
 			struct ThreadName

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -247,7 +247,7 @@ namespace bx
 #elif BX_PLATFORM_WINDOWS
 		// Try to use the new thread naming API from Win10 Creators update onwards if we have it
 		typedef HRESULT (WINAPI *SetThreadDescriptionProc)(HANDLE, PCWSTR);
-		SetThreadDescriptionProc SetThreadDescription = (SetThreadDescriptionProc)(GetProcAddress(GetModuleHandle(TEXT("Kernel32.dll")), "SetThreadDescription"));
+		SetThreadDescriptionProc SetThreadDescription = (SetThreadDescriptionProc)(GetProcAddress(GetModuleHandleA("Kernel32.dll"), "SetThreadDescription"));
 		if (SetThreadDescription)
 		{
 			uint32_t length = (uint32_t)bx::strLen(_name)+1;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -245,17 +245,19 @@ namespace bx
 		pthread_set_name_np(ti->m_handle, _name);
 #	endif // defined(__NetBSD__)
 #elif BX_PLATFORM_WINDOWS
+#	if !BX_CRT_NONE
 		// Try to use the new thread naming API from Win10 Creators update onwards if we have it
 		typedef HRESULT (WINAPI *SetThreadDescriptionProc)(HANDLE, PCWSTR);
-		SetThreadDescriptionProc SetThreadDescription = (SetThreadDescriptionProc)(GetProcAddress(GetModuleHandle(L"Kernel32.dll"), "SetThreadDescription"));
+		SetThreadDescriptionProc SetThreadDescription = (SetThreadDescriptionProc)(GetProcAddress(GetModuleHandle(TEXT("Kernel32.dll")), "SetThreadDescription"));
 		if (SetThreadDescription)
 		{
-			uint32_t length = (uint32_t)bx::strnlen(_name)+1;
+			uint32_t length = (uint32_t)bx::strLen(_name)+1;
 			uint32_t size = length*sizeof(wchar_t);
 			wchar_t* name = (wchar_t*)alloca(size);
 			mbstowcs(name, _name, size-2);
 			SetThreadDescription(ti->m_handle, name);
 		}
+#	endif // BX_CRT_NONE	
 #	if BX_COMPILER_MSVC
 #		pragma pack(push, 8)
 			struct ThreadName

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -251,7 +251,7 @@ namespace bx
 		if ( SetThreadDescription )
 		{
 			uint32_t length = (uint32_t)bx::strnlen(_name) + 1;
-			uint32_t size = length*sizeof( wchar_t );
+			uint32_t size = length*sizeof(wchar_t);
 			wchar_t* name = (wchar_t*)alloca(size);
 			mbstowcs(name, _name, size-2);
 			SetThreadDescription(ti->m_handle, name);


### PR DESCRIPTION
I made a change to call SetThreadDescription() (if available) when setting the thread name, so that it is available in minidumps and to any process that has permission to call GetThreadDescription (as opposed to just being available inside the debugger; for example in a profiler such as Very Sleepy). 

Left the original method there too for when the function is unavailable (or fails; I didn't feel the need to make the distinction).