### PR TITLE
Added __cpluplus check for GCC to disable constexpr similarly to VS2015

### DIFF
--- a/include/bx/macros.h
+++ b/include/bx/macros.h
@@ -115,7 +115,7 @@
 
 /// The return value of the function is solely a function of the arguments.
 ///
-#if BX_COMPILER_MSVC && (BX_COMPILER_MSVC <= 1900)
+#if (BX_COMPILER_MSVC && (BX_COMPILER_MSVC <= 1900)) || (BX_COMPILER_GCC && (__cplusplus < 201402L))
 #	define BX_CONSTEXPR_FUNC BX_CONST_FUNC
 #else
 #	define BX_CONSTEXPR_FUNC constexpr BX_CONST_FUNC


### PR DESCRIPTION
Fixes #201 

What changed relatively to diff seen in that issue: `201300` -> `201402L`. 

Proper reference: https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html
Another relevant link: https://docs.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=vs-2017
And another: https://clang.llvm.org/doxygen/InitPreprocessor_8cpp_source.html

I checked that it compiles with GCC 8 and GCC 7 on Linux with `-std=c++11` in both debug and release configurations. Mingw-w64 with GCC 8 inside also seems to be fine.