### PR TITLE
Emscripten fixes

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -9,6 +9,10 @@
 #include <bx/readerwriter.h> // WriterI
 #include <inttypes.h>        // PRIx*
 
+#if BX_PLATFORM_EMSCRIPTEN
+#include <emscripten/emscripten.h>
+#endif
+
 #if BX_CRT_NONE
 #	include "crt0.h"
 #elif BX_PLATFORM_ANDROID
@@ -43,6 +47,11 @@ namespace bx
 		// NaCl doesn't like int 3:
 		// NativeClient: NaCl module load failed: Validation failure. File violates Native Client safety rules.
 		__asm__ ("int $3");
+#elif BX_PLATFORM_EMSCRIPTEN
+		emscripten_log(EM_LOG_CONSOLE | EM_LOG_ERROR | EM_LOG_C_STACK | EM_LOG_JS_STACK | EM_LOG_DEMANGLE, "debugBreak!");
+        // Doing emscripten_debugger() disables asm.js validation due to an emscripten bug
+		//emscripten_debugger();
+        EM_ASM({ debugger; });
 #else // cross platform implementation
 		int* int3 = (int*)3L;
 		*int3 = 3;

--- a/src/os.cpp
+++ b/src/os.cpp
@@ -233,9 +233,10 @@ namespace bx
 		bool result = len != 0 && len < *_inOutSize;
 		*_inOutSize = len;
 		return result;
-#elif  BX_PLATFORM_PS4     \
-	|| BX_PLATFORM_XBOXONE \
-	|| BX_PLATFORM_WINRT   \
+#elif  BX_PLATFORM_EMSCRIPTEN \
+	|| BX_PLATFORM_PS4        \
+	|| BX_PLATFORM_XBOXONE    \
+	|| BX_PLATFORM_WINRT      \
 	|| BX_CRT_NONE
 		BX_UNUSED(name, _out, _inOutSize);
 		return false;
@@ -275,9 +276,10 @@ namespace bx
 
 #if BX_PLATFORM_WINDOWS
 		::SetEnvironmentVariableA(name, value);
-#elif  BX_PLATFORM_PS4     \
-	|| BX_PLATFORM_XBOXONE \
-	|| BX_PLATFORM_WINRT   \
+#elif  BX_PLATFORM_EMSCRIPTEN \
+	|| BX_PLATFORM_PS4        \
+	|| BX_PLATFORM_XBOXONE    \
+	|| BX_PLATFORM_WINRT      \
 	|| BX_CRT_NONE
 		BX_UNUSED(name, value);
 #else


### PR DESCRIPTION
- getenv/setenv are emulated and aren't really part of the Emscripten platform.  In particular they don't exist when using the "minimal runtime" emscripten flags.

- implement debugBreak in a way that will actually break (writing to 0x3 etc. will not cause any kind of trap with asmjs/wasm because it's just a regular array).