### PR TITLE
don't disable log output with emscripten (also doesn't build otherwise)

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -74,7 +74,7 @@ namespace bx
 #	else
 		NSLog(__CFStringMakeConstantString("%s"), _out);
 #	endif // defined(__OBJC__)
-#elif 0 // BX_PLATFORM_EMSCRIPTEN
+#elif BX_PLATFORM_EMSCRIPTEN
 		emscripten_log(EM_LOG_CONSOLE, "%s", _out);
 #else
 		fputs(_out, stdout);


### PR DESCRIPTION
if this remains an if 0, then it requires stdio to be available, which it isn't with the minimal runtime