### PR TITLE
compile and shaderc fixes

### DIFF
--- a/include/bx/inline/bx.inl
+++ b/include/bx/inline/bx.inl
@@ -24,7 +24,11 @@ namespace bx
 	template<class Ty>
 	inline constexpr bool isTriviallyCopyable()
 	{
+#if _GNUC_VER < 501
+		return __has_trivial_copy(Ty) && __has_trivial_destructor(Ty);
+#else
 		return __is_trivially_copyable(Ty);
+#endif
 	}
 
 	template<>

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -674,6 +674,11 @@ namespace bx
 		StringView ptr = strFind(_str, _word);
 		for (; !ptr.isEmpty(); ptr = strFind(StringView(ptr.getPtr() + len, _str.getTerm() ), _word) )
 		{
+			// added by pgruenbacher July 2019 to brute-force resolve issue where
+			// strings were not being compared correctly.
+			if (_str.getPtr() == ptr.getPtr() && _str.getLength() == len) {
+				return ptr;
+			}
 			char ch = *(ptr.getPtr() - 1);
 			if (isAlphaNum(ch) || '_' == ch)
 			{


### PR DESCRIPTION
compiling on non-home computer was showing some issues when running shaderc on all examples. plus gnuc version issue with the trivially copyable.

you probably have better idea on the string matching, idk what the intent is but my hack fixes the issue. 
essentially the `char ch = *(ptr.getPtr() - 1);` was looking at the memory outside the string, and by blind luck it seems that memory isn't usually alphanumeric, and so hence it passes. 