### PR TITLE
(linux->osx) Autodetect the installed version of clang

### DIFF
--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -377,7 +377,18 @@ function toolchain(_buildDir, _libDir)
 					print("Set OSXCROSS environment variable.")
 				end
 
-				local osxToolchain = "x86_64-apple-darwin15-"
+				-- Autodetct OSXCROSS darwin version
+				-- Do this by using compgen to get clang install. This is a part of bash and always present
+				local handle = io.popen("compgen -c x86_64-apple-darwin | grep \"clang$\"")
+				local osxToolchain = handle:read("*a")
+				handle:close()
+				if (not osxToolchain or osxToolchain == "") then
+					print("Warning: Could not autodetect x86_64-apple-apple-darwin toolchain! Check that your $PATH variable includes $OSXCROSS/target/bin/ !")
+					osxToolchain = "x86_64-apple-darwin15-"	-- Default to this if not found
+				else
+					osxToolchain = osxToolchain:sub(1,osxToolchain:len()-6)   --Get rid of the --clang to get the common part
+				end
+				
 				premake.gcc.cc  = "$(OSXCROSS)/target/bin/" .. osxToolchain .. "clang"
 				premake.gcc.cxx = "$(OSXCROSS)/target/bin/" .. osxToolchain .. "clang++"
 				premake.gcc.ar  = "$(OSXCROSS)/target/bin/" .. osxToolchain .. "ar"


### PR DESCRIPTION
Previously this would always use "x86_64-apple-darwin15-" as the toolchain. Now it autodetects the correct "x86_64-apple-darwinXX-", assuming that x86_64-apple-darwinXX-clang is in $PATH (which it should be is osxcross has been correctly installed by the user). If it does not detect it falls back to "x86_64-apple-darwin15-"