### PR TITLE
emmintrin.h compatibility guard

### DIFF
--- a/include/bx/inline/cpu.inl
+++ b/include/bx/inline/cpu.inl
@@ -12,7 +12,9 @@
 #		include <windows.h>
 #	endif // BX_PLATFORM_WINRT
 
-#	include <emmintrin.h> // _mm_fence
+#	if BX_CPU_X86
+#		include <emmintrin.h> // _mm_fence
+#	endif
 
 extern "C" void _ReadBarrier();
 #	pragma intrinsic(_ReadBarrier)


### PR DESCRIPTION
emmintrin.h is specific to X86 and X64 targets (at least as of MSVC 14.16.27023). Attempting to include this file was causing builds for ARM on UWP to fail. I added conditions to ensure emmintrin.h is only included on x86 and x64. To test, I built (successfully) with the change for UWP on x86, x64, and ARM.