### PR TITLE
Mac os build version

### DIFF
--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -1037,6 +1037,7 @@ function toolchain(_buildDir, _libDir)
 			"-msse2",
 			"-Wunused-value",
 			"-Wundef",
+			"-target x86_64-apple-macos" .. (#macosPlatform > 0 and macosPlatform or "10.11"),
 		}
 		includedirs { path.join(bxDir, "include/compat/osx") }
 

--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -411,6 +411,7 @@ function toolchain(_buildDir, _libDir)
 		or _ACTION == "vs2013"
 		or _ACTION == "vs2015"
 		or _ACTION == "vs2017"
+		or _ACTION == "vs2019"
 		then
 
 		local action = premake.action.current()


### PR DESCRIPTION
Another fix shaderc release build crash. Set the macOS version from toolchain.lua file.

See the closed PR from bgfx project:
https://github.com/bkaradzic/bgfx/pull/1917