### PR TITLE
Avoid warning when mame build with ppc64 (BE)

### DIFF
--- a/include/bx/platform.h
+++ b/include/bx/platform.h
@@ -135,18 +135,18 @@
 #endif //
 
 #if BX_CPU_PPC
-// _LITTLE_ENDIAN exists on ppc64le.
-#	if _LITTLE_ENDIAN
-#		undef  BX_CPU_ENDIAN_LITTLE
-#		define BX_CPU_ENDIAN_LITTLE 1
-#	else
+// __BIG_ENDIAN__ is gcc predefined macro
+#	if defined(__BIG_ENDIAN__)
 #		undef  BX_CPU_ENDIAN_BIG
 #		define BX_CPU_ENDIAN_BIG 1
+#	else
+#		undef  BX_CPU_ENDIAN_LITTLE
+#		define BX_CPU_ENDIAN_LITTLE 1
 #	endif
 #else
 #	undef  BX_CPU_ENDIAN_LITTLE
 #	define BX_CPU_ENDIAN_LITTLE 1
-#endif // BX_PLATFORM_
+#endif // BX_CPU_PPC
 
 // http://sourceforge.net/apps/mediawiki/predef/index.php?title=Operating_Systems
 #if defined(_DURANGO) || defined(_XBOX_ONE)


### PR DESCRIPTION
Avoid warning when mame build with ppc64 (BE)

* use # if defined ... rather than # if ...
  to avoid warning when build on ppc64 (BE)
* replace test of _LITTLE_ENDIAN by __BIG_ENDIAN__ gcc
  predefined macro, to keep default as little endian.

This is a correction of previous commit#77d6f608 pr#199

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>