### PR TITLE
Fixed Android arm64 link error

### DIFF
--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -932,7 +932,6 @@ function toolchain(_buildDir, _libDir)
 			path.join("$(ANDROID_NDK_ROOT)/platforms", androidPlatform, "arch-arm64/usr/lib/crtend_so.o"),
 			"-target aarch64-none-linux-androideabi",
 			"-march=armv8-a",
-			"-Wl,--fix-cortex-a8",
 		}
 
 	configuration { "android-x86" }


### PR DESCRIPTION
Having this flag in the generated project files produces errors like this:

/Users/oliver/Library/Android/sdk/ndk/21.0.6113669/toolchains/aarch64-linux-android-4.9/prebuilt/darwin-x86_64/lib/gcc/aarch64-linux-android/4.9.x/../../../../aarch64-linux-android/bin/ld: unrecognized option '--fix-cortex-a8'