### PR TITLE
Undefine min and max when using msvc

### DIFF
--- a/include/bx/bx.h
+++ b/include/bx/bx.h
@@ -22,6 +22,8 @@
 ///
 #if BX_COMPILER_MSVC
 #	define BX_IGNORE_C4127(_x) bx::ignoreC4127(!!(_x) )
+#	undef min
+#	undef max
 #else
 #	define BX_IGNORE_C4127(_x) (!!(_x) )
 #endif // BX_COMPILER_MSVC


### PR DESCRIPTION
When using msvc and anything that includes minwindef.h on Windows, that header will define min and max and causes compilation errors