### PR TITLE
Generate debug symbols in debug builds only

### DIFF
--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -504,7 +504,6 @@ function toolchain(_buildDir, _libDir)
 		"NoExceptions",
 		"NoEditAndContinue",
 		"NoFramePointer",
-		"Symbols",
 	}
 
 	defines {
@@ -515,6 +514,9 @@ function toolchain(_buildDir, _libDir)
 
 	configuration { "Debug" }
 		targetsuffix "Debug"
+		flags {
+			"Symbols",
+		}
 		defines {
 			"_DEBUG",
 		}


### PR DESCRIPTION
Disables debug symbols generation in release builds.
Although final release executables have symbols stripped, libraries (including `libbgfx-*`) do not. Moreover, some intermediate libs becomes *very* large when symbols are used, notice for example `libspirv-optRelease.a`:

```
Before:                                        | After:
2.5M Nov  8 23:25 example-17-drawstressRelease | 2.5M Nov  8 23:18 example-17-drawstressRelease
923K Nov  8 23:25 example-25-c99Release        | 923K Nov  8 23:18 example-25-c99Release
3.3M Nov  8 23:25 examplesRelease              | 3.3M Nov  8 23:18 examplesRelease
331K Nov  8 23:25 geometrycRelease             | 331K Nov  8 23:18 geometrycRelease
2.7M Nov  8 23:25 geometryvRelease             | 2.7M Nov  8 23:18 geometryvRelease
 15M Nov  8 23:25 libbgfxRelease.a             | 1.6M Nov  8 23:16 libbgfxRelease.a
 16M Nov  8 23:25 libbgfx-shared-libRelease.so | 1.2M Nov  8 23:17 libbgfx-shared-libRelease.so
6.5M Nov  8 23:25 libbimg_decodeRelease.a      | 523K Nov  8 23:17 libbimg_decodeRelease.a
9.9M Nov  8 23:25 libbimg_encodeRelease.a      | 1.6M Nov  8 23:17 libbimg_encodeRelease.a
 12M Nov  8 23:24 libbimgRelease.a             | 518K Nov  8 23:16 libbimgRelease.a
2.3M Nov  8 23:24 libbxRelease.a               | 414K Nov  8 23:16 libbxRelease.a
 18M Nov  8 23:25 libexample-commonRelease.a   | 2.8M Nov  8 23:18 libexample-commonRelease.a
103K Nov  8 23:24 libexample-glueRelease.a     |  25K Nov  8 23:17 libexample-glueRelease.a
222K Nov  8 23:24 libfcppRelease.a             |  73K Nov  8 23:18 libfcppRelease.a
 83M Nov  8 23:25 libglslangRelease.a          | 6.4M Nov  8 23:20 libglslangRelease.a
 13M Nov  8 23:25 libglsl-optimizerRelease.a   | 2.3M Nov  8 23:19 libglsl-optimizerRelease.a
 62M Nov  8 23:25 libspirv-crossRelease.a      | 4.6M Nov  8 23:23 libspirv-crossRelease.a
448M Nov  8 23:26 libspirv-optRelease.a        |  11M Nov  8 23:23 libspirv-optRelease.a
9.1M Nov  8 23:26 shadercRelease               | 9.1M Nov  8 23:23 shadercRelease
 20M Nov  8 23:25 texturecRelease              | 1.8M Nov  8 23:22 texturecRelease
2.5M Nov  8 23:25 texturevRelease              | 2.5M Nov  8 23:23 texturevRelease
```

The increased data generation makes GCC compilation 38% slower, possibly worse on less-than-stellar HW:

```
Before:
$ make clean && time make linux-release64 -j8
real	2m39.954s
user	18m49.542s
sys	0m45.583s

After:
$ make clean && time make linux-release64 -j8
real	1m49.700s
user	13m24.791s
sys	0m33.310s
```