### PR TITLE
Add flag to avoid consuming windows runtime in winrt c++ applications

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -36,7 +36,7 @@
 #	include <windows.h>
 #	include <limits.h>
 #	include <errno.h>
-#	if BX_PLATFORM_WINRT
+#	if !USE_WINRT_CPP && BX_PLATFORM_WINRT
 using namespace Platform;
 using namespace Windows::Foundation;
 using namespace Windows::System::Threading;
@@ -146,7 +146,8 @@ namespace bx
 			return false;
 		}
 #elif  BX_PLATFORM_WINDOWS \
-	|| BX_PLATFORM_XBOXONE
+	|| BX_PLATFORM_XBOXONE \
+	|| USE_WINRT_CPP
 		ti->m_handle = ::CreateThread(NULL
 				, m_stackSize
 				, (LPTHREAD_START_ROUTINE)ti->threadFunc

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -32,15 +32,11 @@
 #	endif // BX_PLATFORM_
 #elif  BX_PLATFORM_WINDOWS \
 	|| BX_PLATFORM_WINRT   \
-	|| BX_PLATFORM_XBOXONE
+	|| BX_PLATFORM_XBOXONE \
+	|| BX_PLATFORM_WINRT
 #	include <windows.h>
 #	include <limits.h>
 #	include <errno.h>
-#	if !WINDOWS_WINRT_NO_RUNTIME && BX_PLATFORM_WINRT
-using namespace Platform;
-using namespace Windows::Foundation;
-using namespace Windows::System::Threading;
-#	endif // BX_PLATFORM_WINRT
 #endif // BX_PLATFORM_
 
 namespace bx
@@ -147,7 +143,7 @@ namespace bx
 		}
 #elif  BX_PLATFORM_WINDOWS \
 	|| BX_PLATFORM_XBOXONE \
-	|| WINDOWS_WINRT_NO_RUNTIME
+	|| BX_PLATFORM_WINRT
 		ti->m_handle = ::CreateThread(NULL
 				, m_stackSize
 				, (LPTHREAD_START_ROUTINE)ti->threadFunc
@@ -159,23 +155,6 @@ namespace bx
 		{
 			return false;
 		}
-#elif BX_PLATFORM_WINRT
-		ti->m_handle = CreateEventEx(nullptr, nullptr, CREATE_EVENT_MANUAL_RESET, EVENT_ALL_ACCESS);
-
-		if (NULL == ti->m_handle)
-		{
-			return false;
-		}
-
-		auto workItemHandler = ref new WorkItemHandler([=](IAsyncAction^)
-			{
-				m_exitCode = ti->threadFunc(this);
-				SetEvent(ti->m_handle);
-			}
-			, CallbackContext::Any
-			);
-
-		ThreadPool::RunAsync(workItemHandler, WorkItemPriority::Normal, WorkItemOptions::TimeSliced);
 #elif BX_PLATFORM_POSIX
 		int result;
 		BX_UNUSED(result);

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -36,7 +36,7 @@
 #	include <windows.h>
 #	include <limits.h>
 #	include <errno.h>
-#	if !USE_WINRT_CPP && BX_PLATFORM_WINRT
+#	if !WINDOWS_WINRT_NO_RUNTIME && BX_PLATFORM_WINRT
 using namespace Platform;
 using namespace Windows::Foundation;
 using namespace Windows::System::Threading;
@@ -147,7 +147,7 @@ namespace bx
 		}
 #elif  BX_PLATFORM_WINDOWS \
 	|| BX_PLATFORM_XBOXONE \
-	|| USE_WINRT_CPP
+	|| WINDOWS_WINRT_NO_RUNTIME
 		ti->m_handle = ::CreateThread(NULL
 				, m_stackSize
 				, (LPTHREAD_START_ROUTINE)ti->threadFunc


### PR DESCRIPTION
Newer UWP winrt c++ dlls/applications have issues consuming static libs that consume the windows runtime. It looks like threading.cpp is currently the only class that uses c++/cx logic requiring Platform, Windows::Foundation, etc. This change introduces a flag that can be set to avoid consuming the windows runtime. Instead of relying on c++/cx threading logic, developers that set the WINDOWS_WINRT_NO_RUNTIME flag will use non c++/cx thread implementations supported by other windows platforms.