### PR TITLE
Fix text files with mixed EOL

### DIFF
--- a/include/bx/inline/string.inl
+++ b/include/bx/inline/string.inl
@@ -276,7 +276,7 @@ namespace bx
 
 			StringView line(curr.getPtr(), m_curr.getPtr() );
 
-			return strRTrim(line, "\n\r");
+			return strRTrim(strRTrim(line, "\n"), "\r");
 		}
 
 		return m_curr;

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -563,7 +563,7 @@ namespace bx
 	StringView strFindNl(const StringView& _str)
 	{
 		StringView str(_str);
-		
+
 		// This method returns the character past the \n, so
 		// there is no need to look for he \r which preceedes it.
 		StringView eol = strFind(str, "\n");
@@ -571,7 +571,7 @@ namespace bx
 		{
 			return StringView(eol.getTerm(), str.getTerm() );
 		}
-		return StringView(str.getTerm(), str.getTerm() );
+		return StringView(_str.getTerm(), _str.getTerm() );
 	}
 
 	StringView strFindEol(const StringView& _str)

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -563,25 +563,15 @@ namespace bx
 	StringView strFindNl(const StringView& _str)
 	{
 		StringView str(_str);
-
-		for (; str.getPtr() != _str.getTerm()
-			; str = StringView(min(str.getPtr() + kFindStep, _str.getTerm() ), min(str.getPtr() + kFindStep*2, _str.getTerm() ) )
-			)
+		
+		// This method returns the character past the \n, so
+		// there is no need to look for he \r which preceedes it.
+		StringView eol = strFind(str, "\n");
+		if (!eol.isEmpty() )
 		{
-			StringView eol = strFind(str, "\r\n");
-			if (!eol.isEmpty() )
-			{
-				return StringView(eol.getTerm(), _str.getTerm() );
-			}
-
-			eol = strFind(str, '\n');
-			if (!eol.isEmpty() )
-			{
-				return StringView(eol.getTerm(), _str.getTerm() );
-			}
+			return StringView(eol.getTerm(), str.getTerm() );
 		}
-
-		return StringView(_str.getTerm(), _str.getTerm() );
+		return StringView(str.getTerm(), str.getTerm() );
 	}
 
 	StringView strFindEol(const StringView& _str)


### PR DESCRIPTION
When reading a file with \r\n eol, and then editing it (with \n) eol, you can end up with mixed eol characters. The linereader behavior of next() looks like it was perhaps just an oversight, and needed to handle the \n case.

strFindNl() only needs to search for the \n - since it returns the string after the \n, the \r won't matter. Also, the first step of the for loop is initialized with the full string, so I don't see how the for loop can run. And even if it does, I don't think the step will help.

Note that strFindEol() has a similar bug, but is trickier to fix (since it backs up before the /r/n). And the for loop - in that case - could potentially split the eol pair and prevent detection.

