### PR TITLE
NX: Mutex and thread NX ready

### DIFF
--- a/src/mutex.cpp
+++ b/src/mutex.cpp
@@ -17,7 +17,8 @@
 	|| BX_PLATFORM_IOS     \
 	|| BX_PLATFORM_OSX     \
 	|| BX_PLATFORM_PS4     \
-	|| BX_PLATFORM_RPI
+	|| BX_PLATFORM_RPI	   \
+	|| BX_PLATFORM_NX
 #	include <pthread.h>
 #elif  BX_PLATFORM_WINDOWS \
 	|| BX_PLATFORM_WINRT   \

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -21,7 +21,8 @@
 	|| BX_PLATFORM_IOS     \
 	|| BX_PLATFORM_OSX     \
 	|| BX_PLATFORM_PS4     \
-	|| BX_PLATFORM_RPI
+	|| BX_PLATFORM_RPI	   \
+	|| BX_PLATFORM_NX
 #	include <pthread.h>
 #	if defined(__FreeBSD__)
 #		include <pthread_np.h>


### PR DESCRIPTION
With these two changes it makes bx buildable without changes on NX.