### PR TITLE
Fix various trim functions

### DIFF
--- a/src/string.cpp
+++ b/src/string.cpp
@@ -480,7 +480,7 @@ namespace bx
 			}
 		}
 
-		return _str;
+		return StringView(_str.getTerm(), _str.getTerm() );
 	}
 
 	StringView strLTrimSpace(const StringView& _str)
@@ -523,7 +523,9 @@ namespace bx
 				{
 					return StringView(ptr, ii + 1);
 				}
-			}
+		}
+
+			return StringView(_str.getPtr(), _str.getPtr());
 		}
 
 		return _str;
@@ -542,6 +544,8 @@ namespace bx
 					return StringView(ptr, ii + 1);
 				}
 			}
+			
+			return StringView(_str.getPtr(), _str.getPtr());
 		}
 
 		return _str;

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -475,12 +475,16 @@ TEST_CASE("StringView", "")
 
 TEST_CASE("Trim", "")
 {
+	REQUIRE(bx::strLTrim("a", "a").isEmpty() );
+	REQUIRE(bx::strRTrim("a", "a").isEmpty() );
+	REQUIRE(bx::strTrim("a", "a").isEmpty() );	
+
 	REQUIRE(0 == bx::strCmp(bx::strLTrim("abvgd", "ab"), "vgd") );
-	REQUIRE(0 == bx::strCmp(bx::strLTrim("abvgd", "vagbd"), "abvgd") );
+	REQUIRE(0 == bx::strCmp(bx::strLTrim("abvgd", "vagbd"), "") );
 	REQUIRE(0 == bx::strCmp(bx::strLTrim("abvgd", "vgd"), "abvgd") );
 	REQUIRE(0 == bx::strCmp(bx::strLTrim("/555333/podmac/", "/"), "555333/podmac/") );
 
-	REQUIRE(0 == bx::strCmp(bx::strRTrim("abvgd", "vagbd"), "abvgd") );
+	REQUIRE(0 == bx::strCmp(bx::strRTrim("abvgd", "vagbd"), "") );
 	REQUIRE(0 == bx::strCmp(bx::strRTrim("abvgd", "abv"), "abvgd") );
 	REQUIRE(0 == bx::strCmp(bx::strRTrim("/555333/podmac/", "/"), "/555333/podmac") );
 
@@ -500,6 +504,10 @@ TEST_CASE("TrimSpace", "")
 	REQUIRE(bx::strLTrimSpace("").isEmpty() );
 	REQUIRE(bx::strRTrimSpace("").isEmpty() );
 	REQUIRE(bx::strTrimSpace( "").isEmpty() );
+
+	REQUIRE(bx::strLTrimSpace("\n").isEmpty() );
+	REQUIRE(bx::strRTrimSpace("\n").isEmpty() );
+	REQUIRE(bx::strTrimSpace( "\n").isEmpty() );
 
 	const bx::StringView t0("1389");
 	const bx::StringView t1("    1389");


### PR DESCRIPTION
Trim doesn't handle the case where the whole string should be trimmed,
due to being composed of only trimmable chars.
For example the string "\n" when trimmed with chars " \t\n\r" should
yield the empty string "" and not the string "\n".
Some test cases were fixed and some were added.