### PR TITLE
Fix various typos

### DIFF
--- a/include/bx/bx.h
+++ b/include/bx/bx.h
@@ -182,7 +182,7 @@ namespace bx
 	///
 	int32_t memCmp(const void* _lhs, const void* _rhs, size_t _numBytes);
 
-	/// Gather data scattered throught memory into linear memory block.
+	/// Gather data scattered through memory into linear memory block.
 	///
 	/// @param _dst Destination pointer.
 	/// @param _src Source pointer.

--- a/include/bx/endian.h
+++ b/include/bx/endian.h
@@ -28,13 +28,13 @@ namespace bx
 	///
 	uint64_t endianSwap(uint64_t _in);
 
-	/// Input argument is encoded as little endian, convert it if neccessary
-	/// depending on host CPU endianess.
+	/// Input argument is encoded as little endian, convert it if necessary
+	/// depending on host CPU endianness.
 	template <typename Ty>
 	Ty toLittleEndian(const Ty _in);
 
-	/// Input argument is encoded as big endian, convert it if neccessary
-	/// depending on host CPU endianess.
+	/// Input argument is encoded as big endian, convert it if necessary
+	/// depending on host CPU endianness.
 	template <typename Ty>
 	Ty toBigEndian(const Ty _in);
 

--- a/include/bx/file.h
+++ b/include/bx/file.h
@@ -134,7 +134,7 @@ namespace bx
 	///
 	bool remove(const FilePath& _filePath, Error* _err = bx::ErrorIgnore{});
 
-	/// Removes file or directory recursivelly.
+	/// Removes file or directory recursively.
 	///
 	bool removeAll(const FilePath& _filePath, Error* _err = bx::ErrorIgnore{});
 

--- a/include/bx/math.h
+++ b/include/bx/math.h
@@ -253,7 +253,7 @@ namespace bx
 	///
 	BX_CONST_FUNC float atan(float _a);
 
-	/// Retruns the inverse tangent of _y/_x.
+	/// Returns the inverse tangent of _y/_x.
 	///
 	BX_CONST_FUNC float atan2(float _y, float _x);
 
@@ -308,11 +308,11 @@ namespace bx
 	///
 	BX_CONSTEXPR_FUNC float nms(float _a, float _b, float _c);
 
-	/// Returns resul of addition (_a + _b).
+	/// Returns result of addition (_a + _b).
 	///
 	BX_CONSTEXPR_FUNC float add(float _a, float _b);
 
-	/// Returns resul of subtracion (_a - _b).
+	/// Returns result of subtracion (_a - _b).
 	///
 	BX_CONSTEXPR_FUNC float sub(float _a, float _b);
 

--- a/include/bx/platform.h
+++ b/include/bx/platform.h
@@ -16,7 +16,7 @@
 #define BX_COMPILER_GCC            0
 #define BX_COMPILER_MSVC           0
 
-// Endianess
+// Endianness
 #define BX_CPU_ENDIAN_BIG    0
 #define BX_CPU_ENDIAN_LITTLE 0
 

--- a/include/bx/readerwriter.h
+++ b/include/bx/readerwriter.h
@@ -174,7 +174,7 @@ namespace bx
 		uint32_t    m_size;
 	};
 
-	/// Sizer writer. Dummy writter that only counts number of bytes written into it.
+	/// Sizer writer. Dummy writer that only counts number of bytes written into it.
 	class SizerWriter : public WriterSeekerI
 	{
 	public:
@@ -271,8 +271,8 @@ namespace bx
 	template<typename Ty>
 	int32_t read(ReaderI* _reader, Ty& _value, Error* _err);
 
-	/// Read value and converts it to host endianess. _fromLittleEndian specifies
-	/// underlying stream endianess.
+	/// Read value and converts it to host endianness. _fromLittleEndian specifies
+	/// underlying stream endianness.
 	template<typename Ty>
 	int32_t readHE(ReaderI* _reader, Ty& _value, bool _fromLittleEndian, Error* _err);
 

--- a/include/bx/string.h
+++ b/include/bx/string.h
@@ -146,19 +146,19 @@ namespace bx
 		int32_t m_capacity;
 	};
 
-	/// Retruns true if character is part of space set.
+	/// Returns true if character is part of space set.
 	bool isSpace(char _ch);
 
 	/// Returns true if string view contains only space characters.
 	bool isSpace(const StringView& _str);
 
-	/// Retruns true if character is uppercase.
+	/// Returns true if character is uppercase.
 	bool isUpper(char _ch);
 
 	/// Returns true if string view contains only uppercase characters.
 	bool isUpper(const StringView& _str);
 
-	/// Retruns true if character is lowercase.
+	/// Returns true if character is lowercase.
 	bool isLower(char _ch);
 
 	/// Returns true if string view contains only lowercase characters.
@@ -167,19 +167,19 @@ namespace bx
 	/// Returns true if character is part of alphabet set.
 	bool isAlpha(char _ch);
 
-	/// Retruns true if string view contains only alphabet characters.
+	/// Returns true if string view contains only alphabet characters.
 	bool isAlpha(const StringView& _str);
 
 	/// Returns true if character is part of numeric set.
 	bool isNumeric(char _ch);
 
-	/// Retruns true if string view contains only numeric characters.
+	/// Returns true if string view contains only numeric characters.
 	bool isNumeric(const StringView& _str);
 
 	/// Returns true if character is part of alpha numeric set.
 	bool isAlphaNum(char _ch);
 
-	/// Returns true if string view contains only alpha-numeric characters.
+	/// Returns true if string view contains only alphanumeric characters.
 	bool isAlphaNum(const StringView& _str);
 
 	/// Returns true if character is part of hexadecimal set.
@@ -194,7 +194,7 @@ namespace bx
 	/// Returns true if string vieww contains only printable characters.
 	bool isPrint(const StringView& _str);
 
-	/// Retruns lower case character representing _ch.
+	/// Returns lower case character representing _ch.
 	char toLower(char _ch);
 
 	/// Lower case string in place assuming length passed is valid.
@@ -231,7 +231,7 @@ namespace bx
 	/// including zero terminator. Copy will be terminated with '\0'.
 	int32_t strCopy(char* _dst, int32_t _dstSize, const StringView& _str, int32_t _num = INT32_MAX);
 
-	/// Concatinate string.
+	/// Concatenate string.
 	int32_t strCat(char* _dst, int32_t _dstSize, const StringView& _str, int32_t _num = INT32_MAX);
 
 	/// Test whether the string _str begins with prefix.
@@ -282,7 +282,7 @@ namespace bx
 	/// Find new line. Returns pointer after new line terminator.
 	StringView strFindNl(const StringView& _str);
 
-	/// Find end of line. Retuns pointer to new line terminator.
+	/// Find end of line. Returns pointer to new line terminator.
 	StringView strFindEol(const StringView& _str);
 
 	/// Returns StringView of word or empty.

--- a/src/commandline.cpp
+++ b/src/commandline.cpp
@@ -46,7 +46,7 @@ namespace bx
 					if ('"' == *curr)
 					{
 						term = '"';
-						++curr; // skip begining quote
+						++curr; // skip beginning quote
 					}
 					else
 					{

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -412,7 +412,7 @@ namespace bx
 				++ptr;
 				--stringLen;
 
-				// Search pattern lenght can't be longer than the string.
+				// Search pattern length can't be longer than the string.
 				if (findLen > stringLen)
 				{
 					return NULL;

--- a/tests/crt_test.cpp
+++ b/tests/crt_test.cpp
@@ -23,14 +23,14 @@ TEST_CASE("memSet", "")
 
 TEST_CASE("memMove", "")
 {
-	const char* orignal = "xxxxabvgd";
+	const char* original = "xxxxabvgd";
 	char str[] = { 'x', 'x', 'x', 'x', 'a', 'b', 'v', 'g', 'd' };
 
 	bx::memMove(&str[4], &str[4], 0);
-	REQUIRE(0 == bx::memCmp(str, orignal, 9) );
+	REQUIRE(0 == bx::memCmp(str, original, 9) );
 
 	bx::memMove(&str[4], &str[4], 5);
-	REQUIRE(0 == bx::memCmp(str, orignal, 9) );
+	REQUIRE(0 == bx::memCmp(str, original, 9) );
 
 	bx::memMove(str, &str[4], 5);
 	REQUIRE(0 == bx::memCmp(str, "abvgd", 5) );
@@ -39,7 +39,7 @@ TEST_CASE("memMove", "")
 	REQUIRE(str[4] == 'a' );
 
 	bx::memSet(str, 'x', 4);
-	REQUIRE(0 == bx::memCmp(str, orignal, 9) );
+	REQUIRE(0 == bx::memCmp(str, original, 9) );
 }
 
 TEST_CASE("scatter/gather", "")

--- a/tools/bin/darwin/lempar.c
+++ b/tools/bin/darwin/lempar.c
@@ -13,7 +13,7 @@
 **
 ** The "lemon" program processes an LALR(1) input grammar file, then uses
 ** this template to construct a parser.  The "lemon" program inserts text
-** at each "%%" line.  Also, any "P-a-r-s-e" identifer prefix (without the
+** at each "%%" line.  Also, any "P-a-r-s-e" identifier prefix (without the
 ** interstitial "-" characters) contained in this template is changed into
 ** the value of the %name directive from the grammar.  Otherwise, the content
 ** of this template is copied straight through into the generate parser

--- a/tools/bin/linux/lempar.c
+++ b/tools/bin/linux/lempar.c
@@ -13,7 +13,7 @@
 **
 ** The "lemon" program processes an LALR(1) input grammar file, then uses
 ** this template to construct a parser.  The "lemon" program inserts text
-** at each "%%" line.  Also, any "P-a-r-s-e" identifer prefix (without the
+** at each "%%" line.  Also, any "P-a-r-s-e" identifier prefix (without the
 ** interstitial "-" characters) contained in this template is changed into
 ** the value of the %name directive from the grammar.  Otherwise, the content
 ** of this template is copied straight through into the generate parser

--- a/tools/bin/windows/lempar.c
+++ b/tools/bin/windows/lempar.c
@@ -13,7 +13,7 @@
 **
 ** The "lemon" program processes an LALR(1) input grammar file, then uses
 ** this template to construct a parser.  The "lemon" program inserts text
-** at each "%%" line.  Also, any "P-a-r-s-e" identifer prefix (without the
+** at each "%%" line.  Also, any "P-a-r-s-e" identifier prefix (without the
 ** interstitial "-" characters) contained in this template is changed into
 ** the value of the %name directive from the grammar.  Otherwise, the content
 ** of this template is copied straight through into the generate parser

--- a/tools/lemon/lemon.c
+++ b/tools/lemon/lemon.c
@@ -980,7 +980,7 @@ PRIVATE void buildshifts(struct lemon *lemp, struct state *stp)
   struct symbol *bsp;  /* Symbol following the dot in configuration "bcfp" */
   struct state *newstp; /* A pointer to a successor state */
 
-  /* Each configuration becomes complete after it contibutes to a successor
+  /* Each configuration becomes complete after it contributes to a successor
   ** state.  Initially, all configurations are incomplete */
   for(cfp=stp->cfp; cfp; cfp=cfp->next) cfp->status = INCOMPLETE;
 
@@ -1819,7 +1819,7 @@ static char *merge(
 **
 ** Return Value:
 **   A pointer to the head of a sorted list containing the elements
-**   orginally in list.
+**   originally in list.
 **
 ** Side effects:
 **   The "next" pointers for elements in list are changed.
@@ -3266,7 +3266,7 @@ void ReportOutput(struct lemon *lemp)
 }
 
 /* Search for the file "name" which is in the same directory as
-** the exacutable */
+** the executable */
 PRIVATE char *pathsearch(char *argv0, char *name, int modemask)
 {
   const char *pathlist;

--- a/tools/lemon/lempar.c
+++ b/tools/lemon/lempar.c
@@ -13,7 +13,7 @@
 **
 ** The "lemon" program processes an LALR(1) input grammar file, then uses
 ** this template to construct a parser.  The "lemon" program inserts text
-** at each "%%" line.  Also, any "P-a-r-s-e" identifer prefix (without the
+** at each "%%" line.  Also, any "P-a-r-s-e" identifier prefix (without the
 ** interstitial "-" characters) contained in this template is changed into
 ** the value of the %name directive from the grammar.  Otherwise, the content
 ** of this template is copied straight through into the generate parser


### PR DESCRIPTION
Found via `codespell -q 3 -S ./3rdparty -L ba,nin,numer,ro`