### PR TITLE
Update msvc compiler name to be able to use vs 2022

### DIFF
--- a/include/bx/platform.h
+++ b/include/bx/platform.h
@@ -337,7 +337,9 @@
 		BX_STRINGIZE(__clang_minor__) "." \
 		BX_STRINGIZE(__clang_patchlevel__)
 #elif BX_COMPILER_MSVC
-#	if BX_COMPILER_MSVC >= 1920 // Visual Studio 2019
+#	if BX_COMPILER_MSVC >= 1930 // Visual Studio 2022
+#		define BX_COMPILER_NAME "MSVC 17.0"
+#	elif BX_COMPILER_MSVC >= 1920 // Visual Studio 2019
 #		define BX_COMPILER_NAME "MSVC 16.0"
 #	elif BX_COMPILER_MSVC >= 1910 // Visual Studio 2017
 #		define BX_COMPILER_NAME "MSVC 15.0"


### PR DESCRIPTION
that is all