### PR TITLE
Full support for osx-arm64 builds

### DIFF
--- a/makefile
+++ b/makefile
@@ -96,6 +96,14 @@ osx-x64-release: .build/projects/gmake-osx-x64
 	make -C .build/projects/gmake-osx config=release
 osx-x64: osx-x64-debug osx-x64-release
 
+.build/projects/gmake-osx-arm64:
+	$(GENIE) --gcc=osx-arm64 gmake
+osx-arm64-debug: .build/projects/gmake-osx-arm64
+	make -C .build/projects/gmake-osx-arm64 config=debug
+osx-arm64-release: .build/projects/gmake-osx-arm64
+	make -C .build/projects/gmake-osx-arm64 config=release
+osx-arm64: osx-arm64-debug osx-arm64-release
+
 .build/projects/gmake-ios-arm:
 	$(GENIE) --gcc=ios-arm gmake
 ios-arm-debug: .build/projects/gmake-ios-arm

--- a/scripts/bin2c.lua
+++ b/scripts/bin2c.lua
@@ -20,6 +20,10 @@ project "bin2c"
 		links {
 			"pthread",
 		}
+	configuration { "osx-*" }
+		linkoptions {
+			"-framework Foundation"
+		}
 
 	configuration { "vs20* or mingw*" }
 		links {


### PR DESCRIPTION
Fixes osx-arm64 builds, while it's currently listed under the genie commands, `make` fails because there's no proper target. bin2c also requires `-framework Foundation` for `NSLog` and friends.