### PR TITLE
Fix bad alignment in Hash when data is added.

### DIFF
--- a/include/bx/hash.h
+++ b/include/bx/hash.h
@@ -32,10 +32,10 @@ namespace bx
 
 	private:
 		///
-		void addAligned(const void* _data, int _len);
+		void addAligned(const uint8_t*& _data, int& _len);
 
 		///
-		void addUnaligned(const void* _data, int _len);
+		void addUnaligned(const uint8_t*& _data, int& _len);
 
 		///
 		static void readUnaligned(const void* _data, uint32_t& _out);


### PR DESCRIPTION
The data pointer given as input may become misaligned
if the m_value computed in a previous op in the `mixTail`
function is not a multiple of 4.

So `mixTail` must be called first, and then the alignment
can be checked properly to call `addAligned` or `addUnaligned`.

Signed-off-by: Ronan Abhamon <ronan.abhamon@gmail.com>