### PR TITLE
OpenBSD also requires including the <pthread_np.h> header.

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -24,7 +24,7 @@
 	|| BX_PLATFORM_RPI	   \
 	|| BX_PLATFORM_NX
 #	include <pthread.h>
-#	if defined(__FreeBSD__)
+#	if defined(__FreeBSD__) || defined(__OpenBSD__)
 #		include <pthread_np.h>
 #	endif
 #	if BX_PLATFORM_LINUX && (BX_CRT_GLIBC < 21200)


### PR DESCRIPTION
Like FreeBSD, <pthread_np.h> is required for pthread_*_np() functions.