### PR TITLE
fixes osx/ios set thread name

### DIFF
--- a/include/bx/bx.h
+++ b/include/bx/bx.h
@@ -14,6 +14,7 @@
 
 #include "platform.h"
 #include "config.h"
+#include "constants.h"
 #include "macros.h"
 #include "debug.h"
 
@@ -32,12 +33,6 @@
 
 namespace bx
 {
-	/// Used to return successful execution of a program code.
-	constexpr int32_t kExitSuccess = 0;
-
-	/// Used to return unsuccessful execution of a program code.
-	constexpr int32_t kExitFailure = 1;
-
 	/// Returns true if type `Ty` is trivially copyable / POD type.
 	template<class Ty>
 	constexpr bool isTriviallyCopyable();
@@ -56,6 +51,14 @@ namespace bx
 
 	/// Swap memory.
 	void swap(void* _a, void* _b, size_t _numBytes);
+
+	/// Returns numeric minimum of type.
+	template<typename Ty>
+	constexpr Ty min();
+
+	/// Returns numeric maximum of type.
+	template<typename Ty>
+	constexpr Ty max();
 
 	/// Returns minimum of two values.
 	template<typename Ty>

--- a/include/bx/constants.h
+++ b/include/bx/constants.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2011-2022 Branimir Karadzic. All rights reserved.
+ * License: https://github.com/bkaradzic/bx/blob/master/LICENSE
+ */
+
+#ifndef BX_CONSTANTS_H_HEADER_GUARD
+#define BX_CONSTANTS_H_HEADER_GUARD
+
+namespace bx
+{
+	/// Used to return successful execution of a program code.
+	constexpr int32_t  kExitSuccess    = 0;
+
+	/// Used to return unsuccessful execution of a program code.
+	constexpr int32_t  kExitFailure    = 1;
+
+	/// The ratio of a circle's circumference to its diameter,
+	constexpr float    kPi             = 3.1415926535897932384626433832795f;
+
+	/// The ratio of a circle's circumference to its radius. Pi multiplied by 2, or Tau. pi*2
+	constexpr float    kPi2            = 6.2831853071795864769252867665590f;
+
+	/// The reciprocal of pi. 1/pi
+	constexpr float    kInvPi          = 1.0f/kPi;
+
+	/// Pi divided by two. pi/2
+	constexpr float    kPiHalf         = 1.5707963267948966192313216916398f;
+
+	/// Pi divided by four. pi/4
+	constexpr float    kPiQuarter      = 0.7853981633974483096156608458199f;
+
+	/// The square root of two. sqrt(2)
+	constexpr float    kSqrt2          = 1.4142135623730950488016887242097f;
+
+	/// ln(10)
+	constexpr float    kLogNat10       = 2.3025850929940456840179914546844f;
+
+	/// The logarithm of the e to base 2. ln(kE) / ln(2)
+	constexpr float    kInvLogNat2     = 1.4426950408889634073599246810019f;
+
+	/// The natural logarithm of the 2. ln(2)
+	constexpr float    kLogNat2Hi      = 0.6931471805599453094172321214582f;
+
+	///
+	constexpr float    kLogNat2Lo      = 1.90821492927058770002e-10f;
+
+	/// The base of natural logarithms. e(1)
+	constexpr float    kE              = 2.7182818284590452353602874713527f;
+
+	///
+	constexpr float    kNearZero       = 1.0f/float(1 << 28);
+
+	/// Smallest normalized positive floating-point number.
+	constexpr float    kFloatSmallest  = 1.175494351e-38f;
+
+	/// Maximum representable floating-point number.
+	constexpr float    kFloatLargest   = 3.402823466e+38f;
+
+	/// Smallest normalized positive double-precision floating-point number.
+	constexpr double   kDoubleSmallest = 2.2250738585072014e-308;
+
+	/// Largest representable double-precision floating-point number.
+	constexpr double   kDoubleLargest  = 1.7976931348623158e+308;
+
+	///
+	extern const float kInfinity;
+
+} // namespace bx
+
+#endif // BX_CONSTANTS_H_HEADER_GUARD

--- a/include/bx/inline/bx.inl
+++ b/include/bx/inline/bx.inl
@@ -59,6 +59,52 @@ namespace bx
 		Ty tmp = _a; _a = _b; _b = tmp;
 	}
 
+	template<class Ty>
+	struct IsSignedT { static constexpr bool value = Ty(-1) < Ty(0); };
+
+	template<class Ty, bool SignT = IsSignedT<Ty>::value>
+	struct Limits;
+
+	template<class Ty>
+	struct Limits<Ty, true>
+	{
+		static constexpr Ty max = ( ( (Ty(1) << ( (sizeof(Ty) * 8) - 2) ) - Ty(1) ) << 1) | Ty(1);
+		static constexpr Ty min = -max - Ty(1);
+	};
+
+	template<class Ty>
+	struct Limits<Ty, false>
+	{
+		static constexpr Ty min = 0;
+		static constexpr Ty max = Ty(-1);
+	};
+
+	template<>
+	struct Limits<float, true>
+	{
+		static constexpr float min = -kFloatLargest;
+		static constexpr float max =  kFloatLargest;
+	};
+
+	template<>
+	struct Limits<double, true>
+	{
+		static constexpr double min = -kDoubleLargest;
+		static constexpr double max =  kDoubleLargest;
+	};
+
+	template<typename Ty>
+	inline constexpr Ty max()
+	{
+		return bx::Limits<Ty>::max;
+	}
+
+	template<typename Ty>
+	inline constexpr Ty min()
+	{
+		return bx::Limits<Ty>::min;
+	}
+
 	template<typename Ty>
 	inline constexpr Ty min(const Ty& _a, const Ty& _b)
 	{

--- a/include/bx/math.h
+++ b/include/bx/math.h
@@ -11,22 +11,6 @@
 
 namespace bx
 {
-	constexpr float kPi         = 3.1415926535897932384626433832795f;
-	constexpr float kPi2        = 6.2831853071795864769252867665590f;
-	constexpr float kInvPi      = 1.0f/kPi;
-	constexpr float kPiHalf     = 1.5707963267948966192313216916398f;
-	constexpr float kPiQuarter  = 0.7853981633974483096156608458199f;
-	constexpr float kSqrt2      = 1.4142135623730950488016887242097f;
-	constexpr float kLogNat10   = 2.3025850929940456840179914546844f;
-	constexpr float kInvLogNat2 = 1.4426950408889634073599246810019f;
-	constexpr float kLogNat2Hi  = 0.6931471805599453094172321214582f;
-	constexpr float kLogNat2Lo  = 1.90821492927058770002e-10f;
-	constexpr float kE          = 2.7182818284590452353602874713527f;
-	constexpr float kNearZero   = 1.0f/float(1 << 28);
-	constexpr float kFloatMin   = 1.175494e-38f;
-	constexpr float kFloatMax   = 3.402823e+38f;
-	extern const float kInfinity;
-
 	///
 	typedef float (*LerpFn)(float _a, float _b, float _t);
 

--- a/include/bx/thread.h
+++ b/include/bx/thread.h
@@ -73,6 +73,7 @@ namespace bx
 		uint32_t  m_stackSize;
 		int32_t   m_exitCode;
 		bool      m_running;
+		char      m_name[32];
 	};
 
 	///

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -87,7 +87,6 @@ namespace bx
 	void* ThreadInternal::threadFunc(void* _arg)
 	{
 		Thread* thread = (Thread*)_arg;
-		thread->setThreadName(thread->m_name);
 		union
 		{
 			void* ptr;
@@ -330,6 +329,7 @@ namespace bx
 #endif // BX_PLATFORM_WINDOWS
 
 		m_sem.post();
+		setThreadName(m_name);
 		int32_t result = m_fn(this, m_userData);
 		return result;
 	}

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -87,6 +87,7 @@ namespace bx
 	void* ThreadInternal::threadFunc(void* _arg)
 	{
 		Thread* thread = (Thread*)_arg;
+		thread->setThreadName(thread->m_name);
 		union
 		{
 			void* ptr;
@@ -135,6 +136,15 @@ namespace bx
 		m_fn = _fn;
 		m_userData = _userData;
 		m_stackSize = _stackSize;
+
+        if (NULL != _name)
+        {
+            strCopy(m_name, sizeof(m_name), _name);
+        }
+        else
+        {
+            m_name[0] = '\0';
+        }
 
 		ThreadInternal* ti = (ThreadInternal*)m_internal;
 #if BX_CRT_NONE
@@ -193,11 +203,6 @@ namespace bx
 
 		m_running = true;
 		m_sem.wait();
-
-		if (NULL != _name)
-		{
-			setThreadName(_name);
-		}
 
 		return true;
 	}

--- a/tests/math_test.cpp
+++ b/tests/math_test.cpp
@@ -8,6 +8,8 @@
 #include <bx/file.h>
 
 #include <math.h>
+#include <stdint.h> // intXX_t
+#include <limits.h> // UCHAR_*
 
 #if !BX_COMPILER_MSVC || BX_COMPILER_MSVC >= 1800
 TEST_CASE("isFinite, isInfinite, isNan", "")
@@ -333,4 +335,40 @@ TEST_CASE("quaternion", "")
 		q2 = bx::fromEuler(euler);
 		REQUIRE(bx::isEqual(quat, q2, 0.001f) );
 	}
+}
+
+TEST_CASE("limits", "")
+{
+	STATIC_REQUIRE(bx::Limits<int8_t>::min == INT8_MIN);
+	STATIC_REQUIRE(bx::Limits<int8_t>::max == INT8_MAX);
+
+	STATIC_REQUIRE(bx::Limits<signed char>::min == CHAR_MIN);
+	STATIC_REQUIRE(bx::Limits<signed char>::max == CHAR_MAX);
+
+	STATIC_REQUIRE(bx::Limits<unsigned char>::min == 0);
+	STATIC_REQUIRE(bx::Limits<unsigned char>::max == UCHAR_MAX);
+
+	STATIC_REQUIRE(bx::Limits<int16_t>::min == INT16_MIN);
+	STATIC_REQUIRE(bx::Limits<int16_t>::max == INT16_MAX);
+
+	STATIC_REQUIRE(bx::Limits<uint16_t>::min == 0);
+	STATIC_REQUIRE(bx::Limits<uint16_t>::max == UINT16_MAX);
+
+	STATIC_REQUIRE(bx::Limits<int32_t>::min == INT32_MIN);
+	STATIC_REQUIRE(bx::Limits<int32_t>::max == INT32_MAX);
+
+	STATIC_REQUIRE(bx::Limits<uint32_t>::min == 0);
+	STATIC_REQUIRE(bx::Limits<uint32_t>::max == UINT32_MAX);
+
+	STATIC_REQUIRE(bx::Limits<int64_t>::min == INT64_MIN);
+	STATIC_REQUIRE(bx::Limits<int64_t>::max == INT64_MAX);
+
+	STATIC_REQUIRE(bx::Limits<uint64_t>::min == 0);
+	STATIC_REQUIRE(bx::Limits<uint64_t>::max == UINT64_MAX);
+
+	STATIC_REQUIRE(bx::Limits<float>::min == std::numeric_limits<float>::lowest() );
+	STATIC_REQUIRE(bx::Limits<float>::max == std::numeric_limits<float>::max() );
+
+	STATIC_REQUIRE(bx::Limits<double>::min == std::numeric_limits<double>::lowest() );
+	STATIC_REQUIRE(bx::Limits<double>::max == std::numeric_limits<double>::max() );
 }

--- a/tests/sort_test.cpp
+++ b/tests/sort_test.cpp
@@ -83,8 +83,8 @@ TEST_CASE("lower/upperBound int32_t", "")
 	const uint32_t resultLowerBound[] = { 0, 1, 4, 4, 5, 6,  9, 11, 12, 13 };
 	const uint32_t resultUpperBound[] = { 1, 4, 4, 5, 6, 9, 11, 12, 13, 14 };
 
-	static_assert(10 == BX_COUNTOF(resultLowerBound) );
-	static_assert(10 == BX_COUNTOF(resultUpperBound) );
+	STATIC_REQUIRE(10 == BX_COUNTOF(resultLowerBound) );
+	STATIC_REQUIRE(10 == BX_COUNTOF(resultUpperBound) );
 
 	for (int32_t key = test[0], keyMax = test[BX_COUNTOF(test)-1], ii = 0; key <= keyMax; ++key, ++ii)
 	{

--- a/tests/sort_test.cpp
+++ b/tests/sort_test.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "test.h"
+#include <bx/bx.h>
 #include <bx/sort.h>
 #include <bx/string.h>
 #include <bx/rng.h>
@@ -110,12 +111,12 @@ void compareTest(const Ty& _min, const Ty& _max)
 {
 	REQUIRE(_min < _max);
 
-	REQUIRE(-1 == compareAscendingTest<Ty>(std::numeric_limits<Ty>::min(), std::numeric_limits<Ty>::max() ) );
-	REQUIRE(-1 == compareAscendingTest<Ty>(Ty(0),                          std::numeric_limits<Ty>::max() ) );
-	REQUIRE( 0 == compareAscendingTest<Ty>(std::numeric_limits<Ty>::min(), std::numeric_limits<Ty>::min() ) );
-	REQUIRE( 0 == compareAscendingTest<Ty>(std::numeric_limits<Ty>::max(), std::numeric_limits<Ty>::max() ) );
-	REQUIRE( 1 == compareAscendingTest<Ty>(std::numeric_limits<Ty>::max(), Ty(0)                          ) );
-	REQUIRE( 1 == compareAscendingTest<Ty>(std::numeric_limits<Ty>::max(), std::numeric_limits<Ty>::min() ) );
+	REQUIRE(-1 == compareAscendingTest<Ty>(bx::min<Ty>(), bx::max<Ty>() ) );
+	REQUIRE(-1 == compareAscendingTest<Ty>(Ty(0),         bx::max<Ty>() ) );
+	REQUIRE( 0 == compareAscendingTest<Ty>(bx::min<Ty>(), bx::min<Ty>() ) );
+	REQUIRE( 0 == compareAscendingTest<Ty>(bx::max<Ty>(), bx::max<Ty>() ) );
+	REQUIRE( 1 == compareAscendingTest<Ty>(bx::max<Ty>(), Ty(0)         ) );
+	REQUIRE( 1 == compareAscendingTest<Ty>(bx::max<Ty>(), bx::min<Ty>() ) );
 
 	REQUIRE(-1 == compareAscendingTest<Ty>(_min, _max) );
 	REQUIRE( 0 == compareAscendingTest<Ty>(_min, _min) );


### PR DESCRIPTION
In osx/ios, pthread_setname_np can only set the name of the current thread. So the thread name must be set in the thread function.