### PR TITLE
fixes osx/ios set thread name

### DIFF
--- a/include/bx/thread.h
+++ b/include/bx/thread.h
@@ -73,6 +73,7 @@ namespace bx
 		uint32_t  m_stackSize;
 		int32_t   m_exitCode;
 		bool      m_running;
+		char      m_name[32];
 	};
 
 	///

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -136,6 +136,15 @@ namespace bx
 		m_userData = _userData;
 		m_stackSize = _stackSize;
 
+        if (NULL != _name)
+        {
+            strCopy(m_name, sizeof(m_name), _name);
+        }
+        else
+        {
+            m_name[0] = '\0';
+        }
+
 		ThreadInternal* ti = (ThreadInternal*)m_internal;
 #if BX_CRT_NONE
 		ti->m_handle = crt0::threadCreate(&ti->threadFunc, _userData, m_stackSize, _name);
@@ -193,11 +202,6 @@ namespace bx
 
 		m_running = true;
 		m_sem.wait();
-
-		if (NULL != _name)
-		{
-			setThreadName(_name);
-		}
 
 		return true;
 	}
@@ -325,6 +329,7 @@ namespace bx
 #endif // BX_PLATFORM_WINDOWS
 
 		m_sem.post();
+		setThreadName(m_name);
 		int32_t result = m_fn(this, m_userData);
 		return result;
 	}


### PR DESCRIPTION
In osx/ios, `pthread_setname_np` can only set the name of the current thread. So the thread name must be set in the thread function.