### PR TITLE
Fix math_tests.cpp on ppc64le

### DIFF
--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -853,6 +853,7 @@ function toolchain(_buildDir, _libDir)
  		objdir (path.join(_buildDir, "linux_ppc64le_gcc/obj"))
  		libdirs { path.join(_libDir, "lib/linux_ppc64le_gcc") }
  		buildoptions {
+			"-fsigned-char",
  			"-Wunused-value",
  			"-Wundef",
 			"-mcpu=power8",


### PR DESCRIPTION
The [2 assertions](https://github.com/bkaradzic/bx/blob/master/tests/math_test.cpp#L345-L346) fails on ppc64le. The macros `CHAR_MAX` and `CHAR_MIN` do not guarantee `signed char` would be returned. The reason behind is that on PowerPC uses `unsigned char` instead of `signed char` like that of x86_64 systems. GCC has `-fsigned-char` build flag to enforce the behaviour.

Ref: https://www.linuxtopia.org/online_books/an_introduction_to_gcc/gccintro_71.html