### PR TITLE
Add linux-ppc64le-clang profile

### DIFF
--- a/makefile
+++ b/makefile
@@ -53,22 +53,6 @@ linux-release64: .build/projects/gmake-linux
 	make -R -C .build/projects/gmake-linux config=release64
 linux: linux-debug64 linux-release64
 
-.build/projects/gmake-linux-ppc64le-clang:
-	$(GENIE) --gcc=linux-ppc64le-clang gmake
-linux-ppc64le-clang-debug: .build/projects/gmake-linux-ppc64le-clang
-	make -R -C .build/projects/gmake-linux-ppc64le-clang config=debug64
-linux-ppc64le-clang-release: .build/projects/gmake-linux-ppc64le-clang
-	make -R -C .build/projects/gmake-linux-ppc64le-clang config=release64
-linux-ppc64le-clang: linux-ppc64le-clang-debug linux-ppc64le-clang-release
-
-.build/projects/gmake-linux-ppc64le-gcc:
-	$(GENIE) --gcc=linux-ppc64le-gcc gmake
-linux-ppc64le-gcc-debug: .build/projects/gmake-linux-ppc64le-gcc
-	make -R -C .build/projects/gmake-linux-ppc64le-gcc config=debug64
-linux-ppc64le-gcc-release: .build/projects/gmake-linux-ppc64le-gcc
-	make -R -C .build/projects/gmake-linux-ppc64le-gcc config=release64
-linux-ppc64le-gcc: linux-ppc64le-gcc-debug linux-ppc64le-gcc-release
-
 .build/projects/gmake-haiku:
 	$(GENIE) --gcc=haiku gmake
 haiku-debug64: .build/projects/gmake-haiku

--- a/makefile
+++ b/makefile
@@ -53,6 +53,22 @@ linux-release64: .build/projects/gmake-linux
 	make -R -C .build/projects/gmake-linux config=release64
 linux: linux-debug64 linux-release64
 
+.build/projects/gmake-linux-ppc64le-clang:
+	$(GENIE) --gcc=linux-ppc64le-clang gmake
+linux-ppc64le-clang-debug: .build/projects/gmake-linux-ppc64le-clang
+	make -R -C .build/projects/gmake-linux-ppc64le-clang config=debug64
+linux-ppc64le-clang-release: .build/projects/gmake-linux-ppc64le-clang
+	make -R -C .build/projects/gmake-linux-ppc64le-clang config=release64
+linux-ppc64le-clang: linux-ppc64le-clang-debug linux-ppc64le-clang-release
+
+.build/projects/gmake-linux-ppc64le-gcc:
+	$(GENIE) --gcc=linux-ppc64le-gcc gmake
+linux-ppc64le-gcc-debug: .build/projects/gmake-linux-ppc64le-gcc
+	make -R -C .build/projects/gmake-linux-ppc64le-gcc config=debug64
+linux-ppc64le-gcc-release: .build/projects/gmake-linux-ppc64le-gcc
+	make -R -C .build/projects/gmake-linux-ppc64le-gcc config=release64
+linux-ppc64le-gcc: linux-ppc64le-gcc-debug linux-ppc64le-gcc-release
+
 .build/projects/gmake-haiku:
 	$(GENIE) --gcc=haiku gmake
 haiku-debug64: .build/projects/gmake-haiku

--- a/scripts/toolchain.lua
+++ b/scripts/toolchain.lua
@@ -77,7 +77,8 @@ function toolchain(_buildDir, _libDir)
 			{ "linux-clang-afl", "Linux (Clang + AFL fuzzer)" },
 			{ "linux-mips-gcc",  "Linux (MIPS, GCC compiler)" },
 			{ "linux-arm-gcc",   "Linux (ARM, GCC compiler)"  },
-			{ "linux-ppc64le-gcc",  "Linux (PPC, GCC compiler)"  },
+			{ "linux-ppc64le-gcc",  "Linux (PPC64LE, GCC compiler)"  },
+			{ "linux-ppc64le-clang",  "Linux (PPC64LE, Clang compiler)"  },
 			{ "ios-arm",         "iOS - ARM"                  },
 			{ "ios-arm64",       "iOS - ARM64"                },
 			{ "ios-simulator",   "iOS - Simulator"            },
@@ -308,6 +309,13 @@ function toolchain(_buildDir, _libDir)
 
 		elseif "linux-ppc64le-gcc" == _OPTIONS["gcc"] then
  			location (path.join(_buildDir, "projects", _ACTION .. "-linux-ppc64le-gcc"))
+
+		elseif "linux-ppc64le-clang" == _OPTIONS["gcc"] then
+			premake.gcc.cc  = "clang"
+			premake.gcc.cxx = "clang++"
+			premake.gcc.ar  = "ar"
+			premake.gcc.llvm = true
+			location (path.join(_buildDir, "projects", _ACTION .. "-linux-ppc64le-clang"))
 
 		elseif "mingw-gcc" == _OPTIONS["gcc"] then
 			if not os.getenv("MINGW") then
@@ -848,23 +856,30 @@ function toolchain(_buildDir, _libDir)
 			"-s MAX_WEBGL_VERSION=2",
 		}
 
-	configuration { "linux-ppc64le-gcc" }
- 		targetdir (path.join(_buildDir, "linux_ppc64le_gcc/bin"))
- 		objdir (path.join(_buildDir, "linux_ppc64le_gcc/obj"))
- 		libdirs { path.join(_libDir, "lib/linux_ppc64le_gcc") }
- 		buildoptions {
+	configuration { "linux-ppc64le*" }
+		buildoptions {
 			"-fsigned-char",
- 			"-Wunused-value",
- 			"-Wundef",
+			"-Wunused-value",
+			"-Wundef",
 			"-mcpu=power8",
- 		}
- 		links {
- 			"rt",
- 			"dl",
- 		}
- 		linkoptions {
- 			"-Wl,--gc-sections",
- 		}
+		}
+		links {
+			"rt",
+			"dl",
+		}
+		linkoptions {
+			"-Wl,--gc-sections",
+		}
+
+	configuration { "linux-ppc64le-gcc" }
+		targetdir (path.join(_buildDir, "linux_ppc64le_gcc/bin"))
+		objdir (path.join(_buildDir, "linux_ppc64le_gcc/obj"))
+		libdirs { path.join(_libDir, "lib/linux_ppc64le_gcc") }
+
+	configuration { "linux-ppc64le-clang" }
+		targetdir (path.join(_buildDir, "linux_ppc64le_clang/bin"))
+		objdir (path.join(_buildDir, "linux_ppc64le_clang/obj"))
+		libdirs { path.join(_libDir, "lib/linux_ppc64le_clang") }
 
 	configuration { "wasm2js" }
 		targetdir (path.join(_buildDir, "wasm2js/bin"))


### PR DESCRIPTION
For Linux distros that use clang over gcc for game development

## Changes

* Add linux-ppc64le-clang profile
* Add makefile target for both gcc and clang profiles