### PR TITLE
Fix use of undefined preprocessor token

### DIFF
--- a/include/bx/platform.h
+++ b/include/bx/platform.h
@@ -160,7 +160,7 @@
 #		define NOMINMAX
 #	endif // NOMINMAX
 //  If _USING_V110_SDK71_ is defined it means we are using the v110_xp or v120_xp toolset.
-#	if defined(_MSC_VER) && (_MSC_VER >= 1700) && (!_USING_V110_SDK71_)
+#	if defined(_MSC_VER) && (_MSC_VER >= 1700) && !defined(_USING_V110_SDK71_)
 #		include <winapifamily.h>
 #	endif // defined(_MSC_VER) && (_MSC_VER >= 1700) && (!_USING_V110_SDK71_)
 #	if !defined(WINAPI_FAMILY) || (WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP)


### PR DESCRIPTION
The platform.h header was using the _USING_V110_SDK71_ without first checking if it was defined, causing compiler warnings for windows builds.