### PR TITLE
Implemented HXCPP compatibility

### DIFF
--- a/include/bx/platform.h
+++ b/include/bx/platform.h
@@ -445,14 +445,14 @@
 #endif // BX_ARCH_
 
 #if defined(__cplusplus)
-#	if   __cplusplus < BX_LANGUAGE_CPP14
-#		error "C++14 standard support is required to build."
-#	elif __cplusplus < BX_LANGUAGE_CPP17
-#		define BX_CPP_NAME "C++14"
-#	elif __cplusplus < BX_LANGUAGE_CPP20
+#	if (__cplusplus < BX_LANGUAGE_CPP17 || HXCPP_CPP14)
+#       define BX_CPP_NAME "C++14"
+#	elif (__cplusplus < BX_LANGUAGE_CPP20 || HXCPP_CPP17)
 #		define BX_CPP_NAME "C++17"
 #	elif __cplusplus < BX_LANGUAGE_CPP23
 #		define BX_CPP_NAME "C++20"
+#   elif __cplusplus < BX_LANGUAGE_CPP14
+#		error "C++14 standard support is required to build."
 #	else
 // See: https://gist.github.com/bkaradzic/2e39896bc7d8c34e042b#orthodox-c
 #		define BX_CPP_NAME "C++WayTooModern"


### PR DESCRIPTION
For some reason, HXCPP can use c++14, but the compiler can't recognize it since it's an extension, which is my assumption. Overall when I compiled and ran the code in my project, it worked just fine.

Also, yes, I'm this library in a Haxe project, lol