### PR TITLE
Fix MSVC include alloca error

### DIFF
--- a/include/bx/bx.h
+++ b/include/bx/bx.h
@@ -6,7 +6,11 @@
 #ifndef BX_H_HEADER_GUARD
 #define BX_H_HEADER_GUARD
 
+#if defined(_WIN32)
+#include <malloc.h>	// alloca
+#else
 #include <alloca.h> // alloca
+#endif
 #include <stdarg.h> // va_list
 #include <stdint.h> // uint32_t
 #include <stdlib.h> // size_t


### PR DESCRIPTION
On MSVC 2022 alloca.h doesn't exist.  alloca actually comes from malloc.h.  Since the platform header comes in later, just use the standard _WIN32 define here.