### PR TITLE
Add fflush to FileWriter

### DIFF
--- a/include/bx/file.h
+++ b/include/bx/file.h
@@ -63,6 +63,9 @@ namespace bx
 		virtual bool open(const FilePath& _filePath, bool _append, Error* _err) override;
 
 		///
+		virtual void flush() override;
+
+		///
 		virtual void close() override;
 
 		///

--- a/include/bx/inline/readerwriter.inl
+++ b/include/bx/inline/readerwriter.inl
@@ -33,6 +33,10 @@ namespace bx
 	{
 	}
 
+	inline FlusherI ::~FlusherI()
+	{
+	}
+
 	inline CloserI::~CloserI()
 	{
 	}
@@ -469,9 +473,14 @@ namespace bx
 		return _process->open(_filePath, _args, _err);
 	}
 
-	inline void close(CloserI* _reader)
+	inline void flush(FlusherI* _flusher)
 	{
-		_reader->close();
+		_flusher->flush();
+	}
+
+	inline void close(CloserI* _closer)
+	{
+		_closer->close();
 	}
 
 } // namespace bx

--- a/include/bx/readerwriter.h
+++ b/include/bx/readerwriter.h
@@ -104,6 +104,16 @@ namespace bx
 		virtual bool open(const FilePath& _filePath, const StringView& _args, Error* _err = ErrorIgnore{}) = 0;
 	};
 
+	/// Flusher interface.
+	struct BX_NO_VTABLE FlusherI
+	{
+		///
+		virtual ~FlusherI() = 0;
+
+		///
+		virtual void flush() = 0;
+	};
+
 	/// Closer interface.
 	struct BX_NO_VTABLE CloserI
 	{
@@ -120,7 +130,7 @@ namespace bx
 	};
 
 	/// File writer interface.
-	struct BX_NO_VTABLE FileWriterI : public WriterOpenI, public CloserI, public WriterSeekerI
+	struct BX_NO_VTABLE FileWriterI : public WriterOpenI, public CloserI, public FlusherI, public WriterSeekerI
 	{
 	};
 

--- a/makefile
+++ b/makefile
@@ -8,6 +8,7 @@ GENIE=../bx/tools/bin/$(OS)/genie
 all:
 	$(GENIE)                       vs2017
 	$(GENIE)                       vs2019
+	$(GENIE)                       vs2022
 	$(GENIE) --gcc=android-arm     gmake
 	$(GENIE) --gcc=android-arm64   gmake
 	$(GENIE) --gcc=android-x86     gmake

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -48,6 +48,10 @@ namespace bx
 			return false;
 		}
 
+		virtual void flush() override
+		{
+		}
+
 		virtual void close() override
 		{
 		}
@@ -198,6 +202,15 @@ namespace bx
 
 			m_open = true;
 			return true;
+		}
+
+		virtual void flush() override
+		{
+			if (m_open
+				&& NULL != m_file)
+			{
+				fflush(m_file);
+			}
 		}
 
 		virtual void close() override
@@ -373,6 +386,15 @@ namespace bx
 			return true;
 		}
 
+		virtual void flush() override
+		{
+			if (m_open
+				&& 0 != m_fd)
+			{
+				crt0::flush(m_fd);
+			}
+		}
+
 		virtual void close() override
 		{
 			if (m_open
@@ -544,6 +566,12 @@ namespace bx
 	{
 		FileWriterImpl* impl = reinterpret_cast<FileWriterImpl*>(m_internal);
 		return impl->open(_filePath, _append, _err);
+	}
+
+	void FileWriter::flush()
+	{
+		FileWriterImpl* impl = reinterpret_cast<FileWriterImpl*>(m_internal);
+		impl->flush();
 	}
 
 	void FileWriter::close()

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -1197,7 +1197,7 @@ namespace bx
 
 	int32_t vsnprintf(char* _out, int32_t _max, const char* _format, va_list _argList)
 	{
-		if (1 < _max)
+		if (1 <= _max)
 		{
 			StaticMemoryBlockWriter writer(_out, uint32_t(_max) );
 

--- a/tests/settings_test.cpp
+++ b/tests/settings_test.cpp
@@ -24,6 +24,7 @@ TEST_CASE("Settings", "")
 	if (bx::open(&writer, filePath, false, bx::ErrorIgnore{}) )
 	{
 		bx::write(&writer, settings, bx::ErrorIgnore{});
+		bx::flush(&writer);
 		bx::close(&writer);
 	}
 


### PR DESCRIPTION
Editor based on bgfx need to create shaderc/texturec process to build shader/texture resource. Call `fflush` before `fclose` can help to catch the time point when the process finish writing contents to binary file.

Not sure if others really need it. I am just collecting codes which maybe are useful in my daily use of bgfx.