### PR TITLE
Remove unions used for type punning and replace with bx::bit_cast()

### DIFF
--- a/include/bx/bx.h
+++ b/include/bx/bx.h
@@ -214,6 +214,10 @@ namespace bx
 	template<typename Ty>
 	constexpr bool isPowerOf2(Ty _a);
 
+	/// Returns a value of type To by reinterpreting the object representation of From.
+	template <typename To, typename From>
+	constexpr To bit_cast(const From& value) noexcept;
+
 	/// Copy memory block.
 	///
 	/// @param _dst Destination pointer.

--- a/include/bx/inline/allocator.inl
+++ b/include/bx/inline/allocator.inl
@@ -24,12 +24,9 @@ namespace bx
 
 	inline void* alignPtr(void* _ptr, size_t _extra, size_t _align)
 	{
-		union { void* ptr; uintptr_t addr; } un;
-		un.ptr = _ptr;
-		uintptr_t unaligned = un.addr + _extra; // space for header
+		uintptr_t unaligned = reinterpret_cast<uintptr_t>(_ptr) + _extra; // space for header
 		uintptr_t aligned = bx::alignUp(unaligned, int32_t(_align) );
-		un.addr = aligned;
-		return un.ptr;
+		return reinterpret_cast<void*>(aligned);
 	}
 
 	inline void* alloc(AllocatorI* _allocator, size_t _size, size_t _align, const Location& _location)

--- a/include/bx/inline/bx.inl
+++ b/include/bx/inline/bx.inl
@@ -7,6 +7,10 @@
 #	error "Must be included from bx/bx.h!"
 #endif // BX_H_HEADER_GUARD
 
+#if __cplusplus >= BX_LANGUAGE_CPP20 && !BX_CRT_NONE
+#	include <bit>
+#endif
+
 namespace bx
 {
 	// Reference(S):
@@ -145,6 +149,21 @@ namespace bx
 	inline constexpr bool isPowerOf2(Ty _a)
 	{
 		return _a && !(_a & (_a - 1) );
+	}
+
+	template <typename To, typename From>
+	inline constexpr To bit_cast(const From& value) noexcept
+	{
+#if __cplusplus >= BX_LANGUAGE_CPP20 && !BX_CRT_NONE
+		return std::bit_cast<To, From>(value);
+#else
+		BX_STATIC_ASSERT(sizeof(To) == sizeof(From), "To and From must be the same size.");
+		BX_STATIC_ASSERT(isTriviallyConstructible<To>(), "Destination target must be trivially constructible.");
+		To result;
+		bx::memCopy(&result, &value, sizeof(To));
+		return result;
+#endif
+
 	}
 
 } // namespace bx

--- a/include/bx/inline/math.inl
+++ b/include/bx/inline/math.inl
@@ -9,6 +9,7 @@
 #	error "Must be included from bx/math.h!"
 #endif // BX_MATH_H_HEADER_GUARD
 
+#include <bx/bx.h>
 #include <bx/simd_t.h>
 #include <bx/uint32_t.h>
 
@@ -26,26 +27,22 @@ namespace bx
 
 	inline BX_CONST_FUNC uint32_t floatToBits(float _a)
 	{
-		union { float f; uint32_t ui; } u = { _a };
-		return u.ui;
+		return bit_cast<uint32_t>(_a);
 	}
 
 	inline BX_CONST_FUNC float bitsToFloat(uint32_t _a)
 	{
-		union { uint32_t ui; float f; } u = { _a };
-		return u.f;
+		return bit_cast<float>(_a);
 	}
 
 	inline BX_CONST_FUNC uint64_t doubleToBits(double _a)
 	{
-		union { double f; uint64_t ui; } u = { _a };
-		return u.ui;
+		return bit_cast<uint64_t>(_a);
 	}
 
 	inline BX_CONST_FUNC double bitsToDouble(uint64_t _a)
 	{
-		union { uint64_t ui; double f; } u = { _a };
-		return u.f;
+		return bit_cast<double>(_a);
 	}
 
 	inline BX_CONST_FUNC uint32_t floatFlip(uint32_t _value)

--- a/include/bx/inline/pixelformat.inl
+++ b/include/bx/inline/pixelformat.inl
@@ -7,6 +7,8 @@
 #	error "Must be included from bx/pixelformat.h"
 #endif // BX_PIXEL_FORMAT_H_HEADER_GUARD
 
+#include <bx/bx.h>
+
 namespace bx
 {
 	inline uint32_t toUnorm(float _value, float _scale)
@@ -735,8 +737,9 @@ namespace bx
 		const float gg = clamp(_src[1], 0.0f, sharedExpMax);
 		const float bb = clamp(_src[2], 0.0f, sharedExpMax);
 		const float mm = max(rr, gg, bb);
-		union { float ff; uint32_t ui; } cast = { mm };
-		int32_t expShared = int32_t(uint32_imax(uint32_t(-expBias-1), ( ( (cast.ui>>23) & 0xff) - 127) ) ) + 1 + expBias;
+
+		uint32_t ui = bit_cast<uint32_t, float>(mm);
+		int32_t expShared = int32_t(uint32_imax(uint32_t(-expBias-1), ( ( (ui>>23) & 0xff) - 127) ) ) + 1 + expBias;
 		float denom = pow(2.0f, float(expShared - expBias - MantissaBits) );
 
 		if ( (1<<MantissaBits) == int32_t(round(mm/denom) ) )

--- a/include/bx/inline/uint32_t.inl
+++ b/include/bx/inline/uint32_t.inl
@@ -27,6 +27,8 @@
 #	error "Must be included from bx/uint32_t.h"
 #endif // BX_UINT32_T_H_HEADER_GUARD
 
+#include <bx/bx.h>
+
 namespace bx
 {
 	inline BX_CONSTEXPR_FUNC uint32_t uint32_li(uint32_t _a)
@@ -649,15 +651,15 @@ namespace bx
 	template<typename Ty>
 	inline BX_CONSTEXPR_FUNC bool isAligned(Ty* _ptr, int32_t _align)
 	{
-		union { const void* ptr; uintptr_t addr; } un = { _ptr };
-		return isAligned(un.addr, _align);
+		uintptr_t addr = reinterpret_cast<uintptr_t>(reinterpret_cast<void*>(_ptr));
+		return isAligned(addr, _align);
 	}
 
 	template<typename Ty>
 	inline BX_CONSTEXPR_FUNC bool isAligned(const Ty* _ptr, int32_t _align)
 	{
-		union { const void* ptr; uintptr_t addr; } un = { _ptr };
-		return isAligned(un.addr, _align);
+		uintptr_t addr = reinterpret_cast<uintptr_t>(reinterpret_cast<const void*>(_ptr));
+		return isAligned(addr, _align);
 	}
 
 	template<typename Ty>
@@ -670,17 +672,17 @@ namespace bx
 	template<typename Ty>
 	inline BX_CONSTEXPR_FUNC Ty* alignDown(Ty* _ptr, int32_t _align)
 	{
-		union { Ty* ptr; uintptr_t addr; } un = { _ptr };
-		un.addr = alignDown(un.addr, _align);
-		return un.ptr;
+		uintptr_t addr = reinterpret_cast<uintptr_t>(_ptr);
+		addr = alignDown(addr, _align);
+		return reinterpret_cast<Ty*>(addr);
 	}
 
 	template<typename Ty>
 	inline BX_CONSTEXPR_FUNC const Ty* alignDown(const Ty* _ptr, int32_t _align)
 	{
-		union { const Ty* ptr; uintptr_t addr; } un = { _ptr };
-		un.addr = alignDown(un.addr, _align);
-		return un.ptr;
+		uintptr_t addr = reinterpret_cast<uintptr_t>(_ptr);
+		addr = alignDown(addr, _align);
+		return reinterpret_cast<const Ty*>(addr);
 	}
 
 	template<typename Ty>
@@ -693,23 +695,22 @@ namespace bx
 	template<typename Ty>
 	inline BX_CONSTEXPR_FUNC Ty* alignUp(Ty* _ptr, int32_t _align)
 	{
-		union { Ty* ptr; uintptr_t addr; } un = { _ptr };
-		un.addr = alignUp(un.addr, _align);
-		return un.ptr;
+		uintptr_t addr = reinterpret_cast<uintptr_t>(_ptr);
+		addr = alignUp(addr, _align);
+		return reinterpret_cast<Ty*>(addr);
 	}
 
 	template<typename Ty>
 	inline BX_CONSTEXPR_FUNC const Ty* alignUp(const Ty* _ptr, int32_t _align)
 	{
-		union { const Ty* ptr; uintptr_t addr; } un = { _ptr };
-		un.addr = alignUp(un.addr, _align);
-		return un.ptr;
+		uintptr_t addr = reinterpret_cast<uintptr_t>(_ptr);
+		addr = alignUp(addr, _align);
+		return reinterpret_cast<const Ty*>(addr);
 	}
 
 	inline BX_CONST_FUNC uint16_t halfFromFloat(float _a)
 	{
-		union { uint32_t ui; float flt; } ftou;
-		ftou.flt = _a;
+		uint32_t ui = bit_cast<uint32_t>(_a);
 
 		const uint32_t one                       = uint32_li(0x00000001);
 		const uint32_t f_s_mask                  = uint32_li(kFloatSignMask);
@@ -728,13 +729,13 @@ namespace bx
 		const uint32_t f_h_m_pos_offset          = uint32_li(0x0000000d);
 		const uint32_t h_nan_min                 = uint32_li(0x00007c01);
 		const uint32_t f_h_e_biased_flag         = uint32_li(0x0000008f);
-		const uint32_t f_s                       = uint32_and(ftou.ui, f_s_mask);
-		const uint32_t f_e                       = uint32_and(ftou.ui, f_e_mask);
+		const uint32_t f_s                       = uint32_and(ui, f_s_mask);
+		const uint32_t f_e                       = uint32_and(ui, f_e_mask);
 		const uint16_t h_s                       = (uint16_t)uint32_srl(f_s, f_h_s_pos_offset);
-		const uint32_t f_m                       = uint32_and(ftou.ui, f_m_mask);
+		const uint32_t f_m                       = uint32_and(ui, f_m_mask);
 		const uint16_t f_e_amount                = (uint16_t)uint32_srl(f_e, f_e_pos);
 		const uint32_t f_e_half_bias             = uint32_sub(f_e_amount, f_h_bias_offset);
-		const uint32_t f_snan                    = uint32_and(ftou.ui, f_snan_mask);
+		const uint32_t f_snan                    = uint32_and(ui, f_snan_mask);
 		const uint32_t f_m_round_mask            = uint32_and(f_m, f_m_round_bit);
 		const uint32_t f_m_round_offset          = uint32_sll(f_m_round_mask, one);
 		const uint32_t f_m_rounded               = uint32_add(f_m, f_m_round_offset);
@@ -817,9 +818,7 @@ namespace bx
 		const uint32_t f_nan_result         = uint32_sels(is_nan_msb, f_em_nan, f_inf_result);
 		const uint32_t f_result             = uint32_or(f_s, f_nan_result);
 
-		union { uint32_t ui; float flt; } utof;
-		utof.ui = f_result;
-		return utof.flt;
+		return bit_cast<float>(f_result);
 	}
 
 } // namespace bx

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -3,6 +3,7 @@
  * License: https://github.com/bkaradzic/bx/blob/master/LICENSE
  */
 
+#include <bx/bx.h>
 #include <bx/os.h>
 #include <bx/thread.h>
 
@@ -82,13 +83,7 @@ namespace bx
 	void* ThreadInternal::threadFunc(void* _arg)
 	{
 		Thread* thread = (Thread*)_arg;
-		union
-		{
-			void* ptr;
-			int32_t i;
-		} cast;
-		cast.i = thread->entry();
-		return cast.ptr;
+		return reinterpret_cast<void*>((intptr_t)thread->entry());
 	}
 #endif // BX_PLATFORM_
 
@@ -213,13 +208,9 @@ namespace bx
 		CloseHandle(ti->m_handle);
 		ti->m_handle = INVALID_HANDLE_VALUE;
 #elif BX_PLATFORM_POSIX
-		union
-		{
-			void* ptr;
-			int32_t i;
-		} cast;
-		pthread_join(ti->m_handle, &cast.ptr);
-		m_exitCode = cast.i;
+		void* ptr;
+		pthread_join(ti->m_handle, &ptr);
+		m_exitCode = (int32_t)reinterpret_cast<intptr_t>(ptr);
 		ti->m_handle = 0;
 #endif // BX_PLATFORM_
 

--- a/tests/math_test.cpp
+++ b/tests/math_test.cpp
@@ -15,20 +15,20 @@ TEST_CASE("isFinite, isInfinite, isNan", "[math]")
 {
 	for (uint64_t ii = 0; ii < UINT32_MAX; ii += rand()%(1<<13)+1)
 	{
-		union { uint32_t ui; float f; } u = { uint32_t(ii) };
+		const float f = bx::bit_cast<float>(uint32_t(ii));
 
 #if BX_PLATFORM_OSX
-		REQUIRE(::__isnanf(u.f)    == bx::isNan(u.f) );
-		REQUIRE(::__isfinitef(u.f) == bx::isFinite(u.f) );
-		REQUIRE(::__isinff(u.f)    == bx::isInfinite(u.f) );
+		REQUIRE(::__isnanf(u.f)    == bx::isNan(f) );
+		REQUIRE(::__isfinitef(u.f) == bx::isFinite(f) );
+		REQUIRE(::__isinff(u.f)    == bx::isInfinite(f) );
 #elif BX_COMPILER_MSVC
-		REQUIRE(!!::isnan(u.f)    == bx::isNan(u.f));
-		REQUIRE(!!::isfinite(u.f) == bx::isFinite(u.f));
-		REQUIRE(!!::isinf(u.f)    == bx::isInfinite(u.f));
+		REQUIRE(!!::isnan(f)    == bx::isNan(f) );
+		REQUIRE(!!::isfinite(f) == bx::isFinite(f) );
+		REQUIRE(!!::isinf(f)    == bx::isInfinite(f) );
 #else
-		REQUIRE(::isnanf(u.f)  == bx::isNan(u.f) );
-		REQUIRE(::finitef(u.f) == bx::isFinite(u.f) );
-		REQUIRE(::isinff(u.f)  == bx::isInfinite(u.f) );
+		REQUIRE(::isnanf(f)  == bx::isNan(f) );
+		REQUIRE(::finitef(f) == bx::isFinite(f) );
+		REQUIRE(::isinff(f)  == bx::isInfinite(f) );
 #endif // BX_PLATFORM_OSX
 	}
 }

--- a/tests/queue_test.cpp
+++ b/tests/queue_test.cpp
@@ -9,14 +9,12 @@
 
 void* bitsToPtr(uintptr_t _ui)
 {
-	union { uintptr_t ui; void* ptr; } cast = { _ui };
-	return cast.ptr;
+	return reinterpret_cast<void*>(_ui);
 }
 
 uintptr_t ptrToBits(void* _ptr)
 {
-	union { void* ptr; uintptr_t ui; } cast = { _ptr };
-	return cast.ui;
+	return reinterpret_cast<uintptr_t>(_ptr);
 }
 
 TEST_CASE("SpSc", "")


### PR DESCRIPTION
Add `bx::bit_cast()` function which performs type punning using the `memcpy()` method before C++20, and makes us of `std::bit_cast` from C++20 onwards.

Replace the use of `union`s used for the purpose of type punning with `bx::bit_cast()`.
Use regular `reinterpret_cast` in place of `union`s when casting between `void*` <-> `intptr_t/uintptr_t`.

Resolves bkaradzic/bx#312