### PR TITLE
Added support for Cheerp compiler

### DIFF
--- a/include/bx/inline/cpu.inl
+++ b/include/bx/inline/cpu.inl
@@ -69,6 +69,8 @@ namespace bx
 	{
 #if BX_COMPILER_MSVC
 		_ReadBarrier();
+#elif BX_PLATFORM_CHEERP
+		__sync_synchronize();
 #else
 		asm volatile("":::"memory");
 #endif // BX_COMPILER_*
@@ -78,6 +80,8 @@ namespace bx
 	{
 #if BX_COMPILER_MSVC
 		_WriteBarrier();
+#elif BX_PLATFORM_CHEERP
+		__sync_synchronize();
 #else
 		asm volatile("":::"memory");
 #endif // BX_COMPILER_*
@@ -87,6 +91,8 @@ namespace bx
 	{
 #if BX_COMPILER_MSVC
 		_ReadWriteBarrier();
+#elif BX_PLATFORM_CHEERP
+		__sync_synchronize();
 #else
 		asm volatile("":::"memory");
 #endif // BX_COMPILER_*

--- a/include/bx/platform.h
+++ b/include/bx/platform.h
@@ -50,6 +50,7 @@
 #define BX_PLATFORM_ANDROID    0
 #define BX_PLATFORM_BSD        0
 #define BX_PLATFORM_EMSCRIPTEN 0
+#define BX_PLATFORM_CHEERP     0
 #define BX_PLATFORM_HAIKU      0
 #define BX_PLATFORM_HURD       0
 #define BX_PLATFORM_IOS        0
@@ -203,6 +204,9 @@
 #elif defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__)
 #	undef  BX_PLATFORM_OSX
 #	define BX_PLATFORM_OSX __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__
+#elif defined(__CHEERP__)
+#   undef BX_PLATFORM_CHEERP
+#   define BX_PLATFORM_CHEERP 1
 #elif defined(__EMSCRIPTEN__)
 #	include <emscripten/version.h>
 #	undef  BX_PLATFORM_EMSCRIPTEN
@@ -270,6 +274,7 @@
 	||  BX_PLATFORM_ANDROID    \
 	||  BX_PLATFORM_BSD        \
 	||  BX_PLATFORM_EMSCRIPTEN \
+	||  BX_PLATFORM_CHEERP     \
 	||  BX_PLATFORM_HAIKU      \
 	||  BX_PLATFORM_HURD       \
 	||  BX_PLATFORM_IOS        \

--- a/src/mutex.cpp
+++ b/src/mutex.cpp
@@ -17,6 +17,7 @@
 	|| BX_PLATFORM_PS4     \
 	|| BX_PLATFORM_RPI	   \
 	|| BX_PLATFORM_NX      \
+	|| BX_PLATFORM_CHEERP  \
 	|| BX_PLATFORM_VISIONOS
 #	include <pthread.h>
 #elif  BX_PLATFORM_WINDOWS \

--- a/src/os.cpp
+++ b/src/os.cpp
@@ -21,6 +21,7 @@
 #	include <psapi.h>
 #elif  BX_PLATFORM_ANDROID    \
 	|| BX_PLATFORM_EMSCRIPTEN \
+	|| BX_PLATFORM_CHEERP     \
 	|| BX_PLATFORM_IOS        \
 	|| BX_PLATFORM_LINUX      \
 	|| BX_PLATFORM_NX         \


### PR DESCRIPTION
- introduced BX_PLATFORM_CHEERP define, which is also a POSIX platform
- full memory barrier (__sync_synchronize()) in place of unsupported inline assembly in wasm functions