### PR TITLE
Don't suggest `/Zc:__cplusplus` for clang compiler on windows

### DIFF
--- a/include/bx/platform.h
+++ b/include/bx/platform.h
@@ -453,9 +453,9 @@
 #endif // BX_ARCH_
 
 #if defined(__cplusplus)
-#	if defined(_MSVC_LANG) && _MSVC_LANG != __cplusplus
+#	if BX_COMPILER_MSVC && defined(_MSVC_LANG) && _MSVC_LANG != __cplusplus
 #			error "When using MSVC you must set /Zc:__cplusplus compiler option."
-#	endif // defined(_MSVC_LANG) && _MSVC_LANG != __cplusplus
+#	endif // BX_COMPILER_MSVC && defined(_MSVC_LANG) && _MSVC_LANG != __cplusplus
 
 #	if   __cplusplus < BX_LANGUAGE_CPP17
 #		error "C++17 standard support is required to build."


### PR DESCRIPTION
This fixes an error when using the clang compiler on windows using `-gnu++23` and `-std=c++23` (llvm 18).
The error message is not meant for clang and `/Zc:__cplusplus` is invalid for clang.

In the case of `llvm 18`, it seems like the value of `_MSVC_LANG` is `202004` and `__cplusplus` is `202302`

LLVM
```
clang version 18.1.6
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: C:\PROGRA~1\LLVM\bin
```

Build CMD example:
```
C:\PROGRA~1\LLVM\bin\CLANG_~1.EXE -DBGFX_CONFIG_DEBUG_ANNOTATION=1 -DBGFX_CONFIG_MULTITHREADED=1 -DBX_CONFIG_DEBUG=1 -DFMT_SHARED -DGLM_ENABLE_EXPERIMENTAL -DGLM_FORCE_LEFT_HANDED -DGLM_FORCE_RADIANS -DIMGUI_DEFINE_MATH_OPERATORS -DOPENBLACK_DEBUG -DSDL_MAIN_HANDLED -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG -DSPDLOG_COMPILED_LIB -DSPDLOG_FMT_EXTERNAL -DSPDLOG_SHARED_LIB -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DCMAKE_INTDIR=\"Debug\" -ID:/a/openblack/openblack/src -ID:/a/openblack/openblack/cmake-build-presets/ninja-multi-vcpkg/include -ID:/a/openblack/openblack/cmake-build-presets/ninja-multi-vcpkg/vcpkg_installed/x64-windows/D:/a/openblack/openblack/cmake-build-presets/ninja-multi-vcpkg/vcpkg_installed/x64-windows/include/bullet -ID:/a/openblack/openblack/components/l3d/include -ID:/a/openblack/openblack/components/pack/include -ID:/a/openblack/openblack/components/lnd/include -ID:/a/openblack/openblack/components/anm/include -ID:/a/openblack/openblack/components/morph/include -ID:/a/openblack/openblack/externals/imgui_user -ID:/a/openblack/openblack/components/ScriptLibrary/include -isystem D:/a/openblack/openblack/cmake-build-presets/ninja-multi-vcpkg/vcpkg_installed/x64-windows/include/bullet -isystem D:/a/openblack/openblack/cmake-build-presets/ninja-multi-vcpkg/vcpkg_installed/x64-windows/include -isystem D:/a/openblack/openblack/cmake-build-presets/ninja-multi-vcpkg/vcpkg_installed/x64-windows/include/SDL2 -isystem D:/a/openblack/openblack/cmake-build-presets/ninja-multi-vcpkg/vcpkg_installed/x64-windows/include/bx/compat/msvc -isystem D:/a/openblack/openblack/cmake-build-presets/ninja-multi-vcpkg/vcpkg_installed/x64-windows/include/AL -isystem D:/a/openblack/openblack/cmake-build-presets/ninja-multi-vcpkg/vcpkg_installed/x64-windows/include/minizip -O0 -g -Xclang -gcodeview -std=gnu++23 -D_DEBUG -D_DLL -D_MT -Xclang --dependent-lib=msvcrtd -Wall -Wextra -pedantic -Wno-unused-private-field -Wno-unused-variable -Wno-unused-parameter -Wno-missing-field-initializers -Wno-deprecated-declarations -ftime-trace -Werror -MD -MT src/CMakeFiles/openblack_lib.dir/Debug/Debug/Gui.cpp.obj -MF src\CMakeFiles\openblack_lib.dir\Debug\Debug\Gui.cpp.obj.d -o src/CMakeFiles/openblack_lib.dir/Debug/Debug/Gui.cpp.obj -c D:/a/openblack/openblack/src/Debug/Gui.cpp
```