### PR TITLE
Fixing OSX build issue

### DIFF
--- a/makefile
+++ b/makefile
@@ -91,9 +91,9 @@ mingw-clang: mingw-clang-debug32 mingw-clang-release32 mingw-clang-debug64 mingw
 .build/projects/gmake-osx-x64:
 	$(GENIE) --gcc=osx-x64 gmake
 osx-x64-debug: .build/projects/gmake-osx-x64
-	make -C .build/projects/gmake-osx config=debug
+	make -C .build/projects/gmake-osx-x64 config=debug
 osx-x64-release: .build/projects/gmake-osx-x64
-	make -C .build/projects/gmake-osx config=release
+	make -C .build/projects/gmake-osx-x64 config=release
 osx-x64: osx-x64-debug osx-x64-release
 
 .build/projects/gmake-osx-arm64:


### PR DESCRIPTION
Current makefile references incorrect folder in osx-x64 build process