### PR TITLE
Fixes: FreeBSD Build

### DIFF
--- a/include/compat/freebsd/dirent.h
+++ b/include/compat/freebsd/dirent.h
@@ -1,1 +1,0 @@
-#include <sys/dirent.h>

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -75,6 +75,7 @@ namespace bx
 	  || BX_PLATFORM_EMSCRIPTEN \
 	  || BX_PLATFORM_IOS        \
 	  || BX_PLATFORM_OSX        \
+	  || BX_PLATFORM_BSD		\
 	  || BX_PLATFORM_VISIONOS
 #		define fseeko64 fseeko
 #		define ftello64 ftello

--- a/src/mutex.cpp
+++ b/src/mutex.cpp
@@ -12,6 +12,7 @@
 #	include <bx/crt0.h>
 #elif  BX_PLATFORM_ANDROID \
 	|| BX_PLATFORM_LINUX   \
+	|| BX_PLATFORM_BSD	   \
 	|| BX_PLATFORM_IOS     \
 	|| BX_PLATFORM_OSX     \
 	|| BX_PLATFORM_PS4     \

--- a/src/os.cpp
+++ b/src/os.cpp
@@ -23,6 +23,7 @@
 	|| BX_PLATFORM_EMSCRIPTEN \
 	|| BX_PLATFORM_IOS        \
 	|| BX_PLATFORM_LINUX      \
+	|| BX_PLATFORM_BSD		  \
 	|| BX_PLATFORM_NX         \
 	|| BX_PLATFORM_OSX        \
 	|| BX_PLATFORM_PS4        \

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -16,6 +16,7 @@
 #	include <bx/crt0.h>
 #elif  BX_PLATFORM_ANDROID \
 	|| BX_PLATFORM_LINUX   \
+	|| BX_PLATFORM_BSD	   \
 	|| BX_PLATFORM_IOS     \
 	|| BX_PLATFORM_OSX     \
 	|| BX_PLATFORM_PS4     \


### PR DESCRIPTION
See [here](https://man.freebsd.org/cgi/man.cgi?query=dir&apropos=0&sektion=5&manpath=FreeBSD+13.3-RELEASE&arch=default&format=html) for why `include/compat/freebsd/dirent.h` was no longer needed; `/usr/include/dirent.h` now covers what that compatibility header was originally used for.

The examples currently don't build with LLVM 17 (some quirks with how they link to system libraries and whatnot) but the tools and the glfw stubs do without too many issues on FreeBSD 14.0 64-bit.