### PR TITLE
Update TinySTL (attempt 2).

### DIFF
--- a/include/tinystl/LICENSE
+++ b/include/tinystl/LICENSE
@@ -1,4 +1,4 @@
- Copyright 2012 Matthew Endsley
+ Copyright 2012-2018 Matthew Endsley
  All rights reserved
 
  Redistribution and use in source and binary forms, with or without

--- a/include/tinystl/allocator.h
+++ b/include/tinystl/allocator.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright 2012 Matthew Endsley
+ * Copyright 2012-2018 Matthew Endsley
  * All rights reserved
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,9 +27,7 @@
 #ifndef TINYSTL_ALLOCATOR_H
 #define TINYSTL_ALLOCATOR_H
 
-#include "stddef.h"
-
-#ifndef TINYSTL_ALLOCATOR
+#include <tinystl/stddef.h>
 
 namespace tinystl {
 
@@ -44,7 +42,8 @@ namespace tinystl {
 	};
 }
 
+#ifndef TINYSTL_ALLOCATOR
 #	define TINYSTL_ALLOCATOR ::tinystl::allocator
-#endif // TINYSTL_ALLOCATOR
+#endif
 
 #endif

--- a/include/tinystl/hash.h
+++ b/include/tinystl/hash.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright 2012 Matthew Endsley
+ * Copyright 2012-2018 Matthew Endsley
  * All rights reserved
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,7 +27,7 @@
 #ifndef TINYSTL_STRINGHASH_H
 #define TINYSTL_STRINGHASH_H
 
-#include "stddef.h"
+#include <tinystl/stddef.h>
 
 namespace tinystl {
 

--- a/include/tinystl/hash_base.h
+++ b/include/tinystl/hash_base.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright 2012 Matthew Endsley
+ * Copyright 2012-2018 Matthew Endsley
  * All rights reserved
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,79 +27,134 @@
 #ifndef TINYSTL_HASH_BASE_H
 #define TINYSTL_HASH_BASE_H
 
-#include "stddef.h"
+#include <tinystl/stddef.h>
+#include <tinystl/traits.h>
 
 namespace tinystl {
 
 	template<typename Key, typename Value>
 	struct pair {
-		typedef Key first_type;
-		typedef Value second_type;
-
 		pair();
+		pair(const pair& other);
+		pair(pair&& other);
 		pair(const Key& key, const Value& value);
+		pair(Key&& key, Value&& value);
+
+		pair& operator=(const pair& other);
+		pair& operator=(pair&& other);
 
 		Key first;
 		Value second;
+
+		using first_type = Key;
+		using second_type = Value;
 	};
 
 	template<typename Key, typename Value>
-	pair<Key, Value>::pair() {
+	inline pair<Key, Value>::pair() {
 	}
 
 	template<typename Key, typename Value>
-	pair<Key, Value>::pair(const Key& key, const Value& value)
+	inline pair<Key, Value>::pair(const pair& other)
+		: first(other.first)
+		, second(other.second)
+	{
+	}
+
+	template<typename Key, typename Value>
+	inline pair<Key, Value>::pair(pair&& other)
+		: first(static_cast<Key&&>(other.first))
+		, second(static_cast<Value&&>(other.second))
+	{
+	}
+
+	template<typename Key, typename Value>
+	inline pair<Key, Value>::pair(const Key& key, const Value& value)
 		: first(key)
 		, second(value)
 	{
 	}
 
 	template<typename Key, typename Value>
-	static inline pair<Key, Value> make_pair(const Key& key, const Value& value) {
-		return pair<Key, Value>(key, value);
+	inline pair<Key, Value>::pair(Key&& key, Value&& value)
+		: first(static_cast<Key&&>(key))
+		, second(static_cast<Value&&>(value))
+	{
+	}
+
+	template<typename Key, typename Value>
+	inline pair<Key, Value>& pair<Key, Value>::operator=(const pair& other) {
+		first = other.first;
+		second = other.second;
+		return *this;
+	}
+
+	template<typename Key, typename Value>
+	inline pair<Key, Value>& pair<Key, Value>::operator=(pair&& other) {
+		first = static_cast<Key&&>(other.first);
+		second = static_cast<Value&&>(other.second);
+		return *this;
+	}
+
+	template<typename Key, typename Value>
+	static inline pair<typename remove_const_reference<Key>::type, typename remove_const_reference<Value>::type>
+	make_pair(Key&& key, Value&& value) {
+		return pair<typename remove_const_reference<Key>::type, typename remove_const_reference<Value>::type>(
+				  static_cast<Key&&>(key)
+				, static_cast<Value&&>(value)
+			);
 	}
 
 
 	template<typename Key, typename Value>
 	struct unordered_hash_node {
 		unordered_hash_node(const Key& key, const Value& value);
+		unordered_hash_node(Key&& key, Value&& value);
 
 		const Key first;
 		Value second;
 		unordered_hash_node* next;
 		unordered_hash_node* prev;
-
-	private:
-		unordered_hash_node& operator=(const unordered_hash_node&);
 	};
 
 	template<typename Key, typename Value>
-	unordered_hash_node<Key, Value>::unordered_hash_node(const Key& key, const Value& value)
+	inline unordered_hash_node<Key, Value>::unordered_hash_node(const Key& key, const Value& value)
 		: first(key)
 		, second(value)
 	{
 	}
 
+	template<typename Key, typename Value>
+	inline unordered_hash_node<Key, Value>::unordered_hash_node(Key&& key, Value&& value)
+		: first(static_cast<Key&&>(key))
+		, second(static_cast<Value&&>(value))
+	{
+	}
+
 	template <typename Key>
 	struct unordered_hash_node<Key, void> {
-		unordered_hash_node(const Key& key);
+		explicit unordered_hash_node(const Key& key);
+		explicit unordered_hash_node(Key&& key);
 
 		const Key first;
 		unordered_hash_node* next;
 		unordered_hash_node* prev;
-
-	private:
-		unordered_hash_node& operator=(const unordered_hash_node&);
 	};
 
 	template<typename Key>
-	unordered_hash_node<Key, void>::unordered_hash_node(const Key& key)
+	inline unordered_hash_node<Key, void>::unordered_hash_node(const Key& key)
 		: first(key)
 	{
 	}
 
+	template<typename Key>
+	inline unordered_hash_node<Key, void>::unordered_hash_node(Key&& key)
+		: first(static_cast<Key&&>(key))
+	{
+	}
+
 	template<typename Key, typename Value>
-	static void unordered_hash_node_insert(unordered_hash_node<Key, Value>* node, size_t hash, unordered_hash_node<Key, Value>** buckets, size_t nbuckets) {
+	static inline void unordered_hash_node_insert(unordered_hash_node<Key, Value>* node, size_t hash, unordered_hash_node<Key, Value>** buckets, size_t nbuckets) {
 		size_t bucket = hash & (nbuckets - 1);
 
 		unordered_hash_node<Key, Value>* it = buckets[bucket + 1];
@@ -223,6 +278,7 @@ namespace tinystl {
 
 	template<typename Node, typename Key>
 	static inline Node unordered_hash_find(const Key& key, Node* buckets, size_t nbuckets) {
+		if (!buckets) return 0;
 		const size_t bucket = hash(key) & (nbuckets - 2);
 		for (Node it = buckets[bucket], end = buckets[bucket+1]; it != end; it = it->next)
 			if (it->first == key)

--- a/include/tinystl/new.h
+++ b/include/tinystl/new.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright 2012 Matthew Endsley
+ * Copyright 2012-2018 Matthew Endsley
  * All rights reserved
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,7 +27,7 @@
 #ifndef TINYSTL_NEW_H
 #define TINYSTL_NEW_H
 
-#include "stddef.h"
+#include <tinystl/stddef.h>
 
 namespace tinystl {
 

--- a/include/tinystl/stddef.h
+++ b/include/tinystl/stddef.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright 2012 Matthew Endsley
+ * Copyright 2012-2018 Matthew Endsley
  * All rights reserved
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,10 +29,13 @@
 
 #if defined(_WIN64)
 	typedef long long unsigned int size_t;
+	typedef long long int ptrdiff_t;
 #elif defined(_WIN32)
 	typedef unsigned int size_t;
-#elif defined (__linux__) && defined(__SIZE_TYPE__)
+	typedef int ptrdiff_t;
+#elif defined (__linux__) && defined(__SIZE_TYPE__) && defined(__PTRDIFF_TYPE__)
 	typedef __SIZE_TYPE__ size_t;
+	typedef __PTRDIFF_TYPE__ ptrdiff_t;
 #else
 #	include <stddef.h>
 #endif

--- a/include/tinystl/string.h
+++ b/include/tinystl/string.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright 2012 Matthew Endsley
+ * Copyright 2012-2018 Matthew Endsley
  * All rights reserved
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,34 +27,37 @@
 #ifndef TINYSTL_STRING_H
 #define TINYSTL_STRING_H
 
-#include <string.h> // strlen
-#include "stddef.h"
-#include "hash.h"
+#include <tinystl/allocator.h>
+#include <tinystl/stddef.h>
+#include <tinystl/hash.h>
 
 namespace tinystl {
 
-	template<typename Alloc>
-	class stringT {
+	template<typename Allocator>
+	class basic_string {
 	public:
-		stringT();
-		stringT(const stringT<Alloc>& other);
-		stringT(const char* sz);
-		stringT(const char* sz, size_t len);
-		~stringT();
+		basic_string();
+		basic_string(const basic_string& other);
+		basic_string(basic_string&& other);
+		basic_string(const char* sz);
+		basic_string(const char* sz, size_t len);
+		~basic_string();
 
-		stringT<Alloc>& operator=(const stringT<Alloc>& other);
+		basic_string& operator=(const basic_string& other);
+		basic_string& operator=(basic_string&& other);
 
 		const char* c_str() const;
 		size_t size() const;
-		bool empty() const;
 
-		void reserve(size_t _size);
-		void resize(size_t _size);
+		void reserve(size_t size);
+		void resize(size_t size);
 
+		void clear();
 		void append(const char* first, const char* last);
-		void append(const char* str);
+		void assign(const char* s, size_t n);
 
-		void swap(stringT<Alloc>& other);
+		void shrink_to_fit();
+		void swap(basic_string& other);
 
 	private:
 		typedef char* pointer;
@@ -63,13 +66,11 @@ namespace tinystl {
 		pointer m_capacity;
 
 		static const size_t c_nbuffer = 12;
-		char m_buffer[12];
+		char m_buffer[12]{0};
 	};
 
-	typedef stringT<TINYSTL_ALLOCATOR> string;
-
-	template<typename Alloc>
-	inline stringT<Alloc>::stringT()
+	template<typename allocator>
+	inline basic_string<allocator>::basic_string()
 		: m_first(m_buffer)
 		, m_last(m_buffer)
 		, m_capacity(m_buffer + c_nbuffer)
@@ -77,8 +78,8 @@ namespace tinystl {
 		resize(0);
 	}
 
-	template<typename Alloc>
-	inline stringT<Alloc>::stringT(const stringT<Alloc>& other)
+	template<typename allocator>
+	inline basic_string<allocator>::basic_string(const basic_string& other)
 		: m_first(m_buffer)
 		, m_last(m_buffer)
 		, m_capacity(m_buffer + c_nbuffer)
@@ -87,8 +88,27 @@ namespace tinystl {
 		append(other.m_first, other.m_last);
 	}
 
-	template<typename Alloc>
-	inline stringT<Alloc>::stringT(const char* sz)
+	template<typename allocator>
+	inline basic_string<allocator>::basic_string(basic_string&& other)
+	{
+		if (other.m_first == other.m_buffer) {
+			m_first = m_buffer;
+			m_last = m_buffer;
+			m_capacity = m_buffer + c_nbuffer;
+			reserve(other.size());
+			append(other.m_first, other.m_last);
+		} else {
+			m_first = other.m_first;
+			m_last = other.m_last;
+			m_capacity = other.m_capacity;
+		}
+		other.m_first = other.m_last = other.m_buffer;
+		other.m_capacity = other.m_buffer + c_nbuffer;
+		other.resize(0);
+	}
+
+	template<typename allocator>
+	inline basic_string<allocator>::basic_string(const char* sz)
 		: m_first(m_buffer)
 		, m_last(m_buffer)
 		, m_capacity(m_buffer + c_nbuffer)
@@ -101,8 +121,8 @@ namespace tinystl {
 		append(sz, sz + len);
 	}
 
-	template<typename Alloc>
-	inline stringT<Alloc>::stringT(const char* sz, size_t len)
+	template<typename allocator>
+	inline basic_string<allocator>::basic_string(const char* sz, size_t len)
 		: m_first(m_buffer)
 		, m_last(m_buffer)
 		, m_capacity(m_buffer + c_nbuffer)
@@ -111,68 +131,73 @@ namespace tinystl {
 		append(sz, sz + len);
 	}
 
-	template<typename Alloc>
-	inline stringT<Alloc>::~stringT() {
+	template<typename allocator>
+	inline basic_string<allocator>::~basic_string() {
 		if (m_first != m_buffer)
-			Alloc::static_deallocate(m_first, m_capacity - m_first);
+			allocator::static_deallocate(m_first, m_capacity - m_first);
 	}
 
-	template<typename Alloc>
-	inline stringT<Alloc>& stringT<Alloc>::operator=(const stringT<Alloc>& other) {
-		stringT<Alloc>(other).swap(*this);
+	template<typename allocator>
+	inline basic_string<allocator>& basic_string<allocator>::operator=(const basic_string& other) {
+		basic_string(other).swap(*this);
 		return *this;
 	}
 
-	template<typename Alloc>
-	inline const char* stringT<Alloc>::c_str() const {
+	template<typename allocator>
+	inline basic_string<allocator>& basic_string<allocator>::operator=(basic_string&& other) {
+		basic_string(static_cast<basic_string&&>(other)).swap(*this);
+		return *this;
+	}
+
+	template<typename allocator>
+	inline const char* basic_string<allocator>::c_str() const {
 		return m_first;
 	}
 
-	template<typename Alloc>
-	inline size_t stringT<Alloc>::size() const
+	template<typename allocator>
+	inline size_t basic_string<allocator>::size() const
 	{
 		return (size_t)(m_last - m_first);
 	}
 
-	template<typename Alloc>
-	inline bool stringT<Alloc>::empty() const
-	{
-		return 0 == size();
-	}
-
-	template<typename Alloc>
-	inline void stringT<Alloc>::reserve(size_t capacity) {
-		if (m_first + capacity + 1 <= m_capacity) {
+	template<typename allocator>
+	inline void basic_string<allocator>::reserve(size_t capacity) {
+		if (m_first + capacity + 1 <= m_capacity)
 			return;
-		}
 
-		const size_t _size = (size_t)(m_last - m_first);
+		const size_t size = (size_t)(m_last - m_first);
 
-		pointer newfirst = (pointer)Alloc::static_allocate(capacity + 1);
-		for (pointer it = m_first, newit = newfirst, end = m_last; it != end; ++it, ++newit) {
+		pointer newfirst = (pointer)allocator::static_allocate(capacity + 1);
+		for (pointer it = m_first, newit = newfirst, end = m_last; it != end; ++it, ++newit)
 			*newit = *it;
-		}
-
-		if (m_first != m_buffer) {
-			Alloc::static_deallocate(m_first, m_capacity - m_first);
-		}
+		if (m_first != m_buffer)
+			allocator::static_deallocate(m_first, m_capacity - m_first);
 
 		m_first = newfirst;
-		m_last = newfirst + _size;
+		m_last = newfirst + size;
 		m_capacity = m_first + capacity;
 	}
 
-	template<typename Alloc>
-	inline void stringT<Alloc>::resize(size_t _size) {
-		reserve(_size);
-		for (pointer it = m_last, end = m_first + _size + 1; it < end; ++it)
-			*it = 0;
+	template<typename allocator>
+	inline void basic_string<allocator>::resize(size_t size) {
+		const size_t prevSize = m_last-m_first;
+		reserve(size);
+		if (size > prevSize)
+			for (pointer it = m_last, end = m_first + size + 1; it < end; ++it)
+				*it = 0;
+		else if (m_last != m_first)
+			m_first[size] = 0;
 
-		m_last += _size;
+		m_last = m_first + size;
 	}
 
-	template<typename Alloc>
-	inline void stringT<Alloc>::append(const char* first, const char* last) {
+	template<typename allocator>
+	inline void basic_string<allocator>::clear() {
+		resize(0);
+	}
+
+	template<typename allocator>
+	inline void basic_string<allocator>::append(const char* first, const char* last) {
 		const size_t newsize = (size_t)((m_last - m_first) + (last - first) + 1);
 		if (m_first + newsize > m_capacity)
 			reserve((newsize * 3) / 2);
@@ -182,46 +207,62 @@ namespace tinystl {
 		*m_last = 0;
 	}
 
-	template<typename Alloc>
-	inline void stringT<Alloc>::append(const char* str) {
-		append(str, str + strlen(str) );
+	template<typename allocator>
+	inline void basic_string<allocator>::assign(const char* sz, size_t n) {
+		clear();
+		append(sz, sz+n);
 	}
 
-	template<typename Alloc>
-	inline void stringT<Alloc>::swap(stringT<Alloc>& other) {
-		const pointer tfirst = m_first, tlast = m_last, tcapacity = m_capacity;
-		m_first = other.m_first, m_last = other.m_last, m_capacity = other.m_capacity;
-		other.m_first = tfirst, other.m_last = tlast, other.m_capacity = tcapacity;
+	template<typename allocator>
+	inline void basic_string<allocator>::shrink_to_fit() {
+		if (m_first == m_buffer) {
+		} else if (m_last == m_first) {
+			const size_t capacity = (size_t)(m_capacity - m_first);
+			if (capacity)
+				allocator::static_deallocate(m_first, capacity+1);
+			m_capacity = m_first;
+		} else if (m_capacity != m_last) {
+			const size_t size = (size_t)(m_last - m_first);
+			char* newfirst = (pointer)allocator::static_allocate(size+1);
+			for (pointer in = m_first, out = newfirst; in != m_last + 1; ++in, ++out)
+				*out = *in;
+			if (m_first != m_capacity)
+				allocator::static_deallocate(m_first, m_capacity+1-m_first);
+			m_first = newfirst;
+			m_last = newfirst+size;
+			m_capacity = m_last;
+		}
+	}
 
-		char tbuffer[c_nbuffer];
-
-		if (m_first == other.m_buffer)
-			for  (pointer it = other.m_buffer, end = m_last, out = tbuffer; it != end; ++it, ++out)
-				*out = *it;
-
-		if (other.m_first == m_buffer) {
-			other.m_last = other.m_last - other.m_first + other.m_buffer;
-			other.m_first = other.m_buffer;
-			other.m_capacity = other.m_buffer + c_nbuffer;
-
-			for (pointer it = other.m_first, end = other.m_last, in = m_buffer; it != end; ++it, ++in)
-				*it = *in;
-			*other.m_last = 0;
+	template<typename allocator>
+	inline void basic_string<allocator>::swap(basic_string& other) {
+		{
+			const pointer tfirst = m_first, tlast = m_last, tcapacity = m_capacity;
+			m_first = other.m_first, m_last = other.m_last, m_capacity = other.m_capacity;
+			other.m_first = tfirst, other.m_last = tlast, other.m_capacity = tcapacity;
 		}
 
+		for (size_t i = 0; i < c_nbuffer; ++i) {
+			const char temp = m_buffer[i];
+			m_buffer[i] = other.m_buffer[i];
+			other.m_buffer[i] = temp;
+		}
 		if (m_first == other.m_buffer) {
-			m_last = m_last - m_first + m_buffer;
+			int len = m_last - m_first;
 			m_first = m_buffer;
+			m_last = m_buffer + len;
 			m_capacity = m_buffer + c_nbuffer;
-
-			for (pointer it = m_first, end = m_last, in = tbuffer; it != end; ++it, ++in)
-				*it = *in;
-			*m_last = 0;
+		}
+		if (other.m_first == m_buffer) {
+			int len = other.m_last - other.m_first;
+			other.m_first = other.m_buffer;
+			other.m_last = other.m_buffer + len;
+			other.m_capacity = other.m_buffer + c_nbuffer;
 		}
 	}
 
-	template<typename Alloc>
-	inline bool operator==(const stringT<Alloc>& lhs, const stringT<Alloc>& rhs) {
+	template<typename allocatorl, typename allocatorr>
+	inline bool operator==(const basic_string<allocatorl>& lhs, const basic_string<allocatorr>& rhs) {
 		typedef const char* pointer;
 
 		const size_t lsize = lhs.size(), rsize = rhs.size();
@@ -237,10 +278,12 @@ namespace tinystl {
 		return true;
 	}
 
-	template<typename Alloc>
-	static inline size_t hash(const stringT<Alloc>& value) {
+	template<typename allocator>
+	static inline size_t hash(const basic_string<allocator>& value) {
 		return hash_string(value.c_str(), value.size());
 	}
+
+	typedef basic_string<TINYSTL_ALLOCATOR> string;
 }
 
 #endif

--- a/include/tinystl/string_view.h
+++ b/include/tinystl/string_view.h
@@ -1,0 +1,147 @@
+/*-
+ * Copyright 2012-1017 Matthew Endsley
+ * All rights reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted providing that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TINYSTL_STRING_VIEW_H
+#define TINYSTL_STRING_VIEW_H
+
+#include <tinystl/stddef.h>
+
+namespace tinystl {
+
+	class string_view
+	{
+	public:
+		typedef char value_type;
+		typedef char* pointer;
+		typedef const char* const_pointer;
+		typedef char& reference;
+		typedef const char& const_reference;
+		typedef const_pointer iterator;
+		typedef const_pointer const_iterator;
+		typedef size_t size_type;
+		typedef ptrdiff_t difference_type;
+
+		static constexpr size_type npos = size_type(-1);
+
+		constexpr string_view();
+		constexpr string_view(const char* s, size_type count);
+		constexpr string_view(const char* s);
+		constexpr string_view(const string_view&) = default;
+		string_view& operator=(const string_view&) = default;
+
+		constexpr const char* data() const;
+		constexpr char operator[](size_type pos) const;
+		constexpr size_type size() const;
+		constexpr bool empty() const;
+		constexpr iterator begin() const;
+		constexpr const_iterator cbegin() const;
+		constexpr iterator end() const;
+		constexpr const_iterator cend() const;
+		constexpr string_view substr(size_type pos = 0, size_type count = npos) const;
+		constexpr void swap(string_view& v);
+
+	private:
+		string_view(decltype(nullptr)) = delete;
+
+		static constexpr size_type strlen(const char*);
+
+		const char* m_str;
+		size_type m_size;
+	};
+
+	constexpr string_view::string_view()
+		: m_str(nullptr)
+		, m_size(0)
+	{
+	}
+
+	constexpr string_view::string_view(const char* s, size_type count)
+		: m_str(s)
+		, m_size(count)
+	{
+	}
+
+	constexpr string_view::string_view(const char* s)
+		: m_str(s)
+		, m_size(strlen(s))
+	{
+	}
+
+	constexpr const char* string_view::data() const {
+		return m_str;
+	}
+
+	constexpr char string_view::operator[](size_type pos) const {
+		return m_str[pos];
+	}
+
+	constexpr string_view::size_type string_view::size() const {
+		return m_size;
+	}
+
+	constexpr bool string_view::empty() const {
+		return 0 == m_size;
+	}
+
+	constexpr string_view::iterator string_view::begin() const {
+		return m_str;
+	}
+
+	constexpr string_view::const_iterator string_view::cbegin() const {
+		return m_str;
+	}
+
+	constexpr string_view::iterator string_view::end() const {
+		return m_str + m_size;
+	}
+
+	constexpr string_view::const_iterator string_view::cend() const {
+		return m_str + m_size;
+	}
+
+	constexpr string_view string_view::substr(size_type pos, size_type count) const {
+		return string_view(m_str + pos, npos == count ? m_size - pos : count);
+	}
+
+	constexpr void string_view::swap(string_view& v) {
+		const char* strtmp = m_str;
+		size_type sizetmp = m_size;
+		m_str = v.m_str;
+		m_size = v.m_size;
+		v.m_str = strtmp;
+		v.m_size = sizetmp;
+	}
+
+	constexpr string_view::size_type string_view::strlen(const char* s) {
+		for (size_t len = 0; ; ++len) {
+			if (0 == s[len]) {
+				return len;
+			}
+		}
+	}
+}
+
+#endif // TINYSTL_STRING_VIEW_H

--- a/include/tinystl/traits.h
+++ b/include/tinystl/traits.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright 2012 Matthew Endsley
+ * Copyright 2012-2018 Matthew Endsley
  * All rights reserved
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,9 +27,9 @@
 #ifndef TINYSTL_TRAITS_H
 #define TINYSTL_TRAITS_H
 
-#include "new.h"
+#include <tinystl/new.h>
 
-#if defined(__GNUC__) && defined(__is_pod)
+#if defined(__GNUC__)
 #	define TINYSTL_TRY_POD_OPTIMIZATION(t) __is_pod(t)
 #elif defined(_MSC_VER)
 #	define TINYSTL_TRY_POD_OPTIMIZATION(t) (!__is_class(t) || __is_pod(t))
@@ -80,6 +80,46 @@ namespace tinystl {
 	static inline void move_construct(T* a, T& b) {
 		move_construct_impl(a, b, (T*)0);
 	}
+
+	template<typename T>
+	struct remove_reference {
+		typedef T type;
+	};
+
+	template<typename T>
+	struct remove_reference<T&> {
+		typedef T type;
+	};
+
+	template<typename T>
+	struct remove_reference<T&&> {
+		typedef T type;
+	};
+
+	template<typename T>
+	struct remove_const {
+		typedef T type;
+	};
+
+	template<typename T>
+	struct remove_const<const T> {
+		typedef T type;
+	};
+
+	template<typename T>
+	struct remove_const<const T&> {
+		typedef T& type;
+	};
+
+	template<typename T>
+	struct remove_const<const T&&> {
+		typedef T&& type;
+	};
+
+	template<typename T>
+	struct remove_const_reference {
+		typedef typename remove_reference<typename remove_const<T>::type>::type type;
+	};
 }
 
 #endif

--- a/scripts/update_tinystl.sh
+++ b/scripts/update_tinystl.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -eux
+
+if [ $# != 1 ]; then
+	echo "Usage: $0 <tinystl-upstream-folder>"
+	exit 1
+fi
+
+SRC_DIR=$1
+DST_DIR="include/tinystl"
+
+pushd $(dirname $0)/..
+
+cp $SRC_DIR/include/TINYSTL/*.h $DST_DIR/
+find $DST_DIR -iname "*.h" -exec sed --in-place 's/<TINYSTL\//<tinystl\//g' {} \;
+
+popd

--- a/tests/string_test.cpp
+++ b/tests/string_test.cpp
@@ -9,6 +9,7 @@
 #include <bx/handlealloc.h>
 #include <bx/sort.h>
 #include <string>
+#include <tinystl/string.h>
 
 bx::AllocatorI* g_allocator;
 
@@ -636,4 +637,94 @@ TEST_CASE("0terminated", "[string]")
 	st = strTrimSuffix(t0, "89");
 	REQUIRE(2 == st.getLength() );
 	REQUIRE(st.is0Terminated() );
+}
+
+TEST(tinystl_string_constructor) {
+	using tinystl::string;
+	{
+		string s;
+		CHECK( s.size() == 0 );
+	}
+	{
+		string s("hello");
+		CHECK( s.size() == 5 );
+		CHECK( 0 == strcmp(s.c_str(), "hello") );
+	}
+	{
+		string s("hello world", 5);
+		CHECK( s.size() == 5 );
+		CHECK( 0 == strcmp(s.c_str(), "hello") );
+	}
+	{
+		const string other("hello");
+		string s = other;
+
+		CHECK( s.size() == 5 );
+		CHECK( 0 == strcmp(s.c_str(), "hello") );
+	}
+	{
+		string other("hello");
+		string s = std::move(other);
+
+		CHECK( s.size() == 5 );
+		CHECK( 0 == strcmp(s.c_str(), "hello") );
+		CHECK( other.size() == 0 );
+	}
+}
+
+TEST(tinystl_string_assign) {
+	using tinystl::string;
+	{
+		const string other("hello");
+		string s("new");
+		s = other;
+
+		CHECK( s.size() == 5 );
+		CHECK( 0 == strcmp(s.c_str(), "hello") );
+	}
+	{
+		string other("hello");
+		string s("new");
+		s = std::move(other);
+
+		CHECK( s.size() == 5 );
+		CHECK( 0 == strcmp(s.c_str(), "hello") );
+		CHECK( other.size() == 0 );
+	}
+
+	{
+		const string other("hello longer string here");
+		string s("short");
+		s = other;
+
+		CHECK( s.size() == 24 );
+		CHECK( 0 == strcmp(s.c_str(), "hello longer string here") );
+	}
+	{
+		string other("hello longer string here");
+		string s("short");
+		s = std::move(other);
+
+		CHECK( s.size() == 24 );
+		CHECK( 0 == strcmp(s.c_str(), "hello longer string here") );
+		CHECK( other.size() == 0 );
+	}
+
+	{
+		const string other("short");
+		string s("hello longer string here");
+		s = other;
+
+		CHECK( s.size() == 5 );
+		CHECK( 0 == strcmp(s.c_str(), "short") );
+	}
+	{
+		string other("short");
+		string s("hello longer string here");
+		s = std::move(other);
+
+		CHECK( s.size() == 5 );
+		CHECK( 0 == strcmp(s.c_str(), "short") );
+		CHECK( other.size() == 0 );
+	}
 }

--- a/tests/unordered_map_test.cpp
+++ b/tests/unordered_map_test.cpp
@@ -1,0 +1,205 @@
+/*-
+* Copyright 2012-2018 Matthew Endsley
+* All rights reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted providing that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+* STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+* IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "test.h"
+
+#include <tinystl/unordered_map.h>
+#include <tinystl/string.h>
+#include <utility>
+
+template<typename K, typename V>
+static void comparemaps(const tinystl::unordered_map<K, V>& m, const tinystl::unordered_map<K, V>& expected) {
+	CHECK( m.size() == expected.size() );
+
+	typedef typename tinystl::unordered_map<K, V>::const_iterator iterator;
+	for (iterator it = expected.begin(), end = expected.end(); it != end; ++it) {
+		iterator found = m.find((*it).first);
+		CHECK( found != m.end() );
+		CHECK( (*found).second == (*it).second );
+	}
+}
+
+TEST(uomap_constructor) {
+	typedef tinystl::unordered_map<int, int> unordered_map;
+	using tinystl::make_pair;
+
+	unordered_map baseline;
+	comparemaps(baseline, baseline); // test with empty maps
+	baseline.insert(make_pair(5, 1));
+	baseline.insert(make_pair(6, 2));
+	CHECK( 2 == baseline.size() );
+	CHECK( baseline.find(5) != baseline.end() );
+	CHECK( baseline[5] == 1 );
+	CHECK( baseline.find(6) != baseline.end() );
+	CHECK( baseline[6] == 2 );
+	comparemaps(baseline, baseline);
+
+	{
+		unordered_map m;
+
+		CHECK( m.empty() );
+		CHECK( m.size() == 0 );
+	}
+
+	{
+		unordered_map m = baseline;
+
+		comparemaps(m, baseline);
+	}
+
+	{
+		unordered_map other = baseline;
+		unordered_map m = std::move(other);
+
+		comparemaps(m, baseline);
+		CHECK( other.empty() );
+	}
+}
+
+TEST(uomap_assign) {
+	typedef tinystl::unordered_map<int, int> unordered_map;
+	using tinystl::make_pair;
+
+	unordered_map baseline;
+	baseline.insert(make_pair(5, 1));
+	baseline.insert(make_pair(6, 2));
+	CHECK( 2 == baseline.size() );
+	CHECK( baseline.find(5) != baseline.end() );
+	CHECK( baseline[5] == 1 );
+	CHECK( baseline.find(6) != baseline.end() );
+	CHECK( baseline[6] == 2 );
+	comparemaps(baseline, baseline);
+
+	{
+		unordered_map m;
+		m = baseline;
+
+		comparemaps(m, baseline);
+	}
+
+	{
+		unordered_map m;
+		for (int ii = 0; ii != 10; ++ii)
+			m.insert(make_pair(ii, 10*ii));
+
+		m = baseline;
+
+		comparemaps(m, baseline);
+	}
+
+	{
+		unordered_map other = baseline;
+		unordered_map m;
+		m = std::move(other);
+
+		comparemaps(m, baseline);
+		CHECK( other.empty() );
+	}
+
+	{
+		unordered_map other = baseline;
+		unordered_map m;
+		for (int ii = 0; ii != 10; ++ii)
+			m.insert(make_pair(ii, 10*ii));
+
+		m = std::move(other);
+
+		comparemaps(m, baseline);
+		CHECK( other.empty() );
+	}
+}
+
+TEST(uomap_insert) {
+	using tinystl::string;
+	using tinystl::pair;
+	typedef tinystl::unordered_map<string, string> unordered_map;
+	typedef pair<unordered_map::iterator, bool> inspair;
+
+	{
+		unordered_map m;
+		m.insert(make_pair(string("hello"), string("world")));
+		CHECK( m.find("hello") != m.end() );
+	}
+
+	{
+		const pair<string, string> p("hello", "world");
+		unordered_map m;
+		inspair p1 = m.insert(p);
+		CHECK( p1.second );
+		CHECK( (*p1.first).first == tinystl::string("hello") );
+		CHECK( (*p1.first).second == tinystl::string("world") );
+
+		inspair p2 = m.insert(p);
+		CHECK( !p2.second );
+		CHECK( p2.first == p1.first );
+	}
+
+	{
+		unordered_map m;
+		m.emplace(pair<string, string>("hello", "world"));
+
+		CHECK( m.find("hello") != m.end() );
+	}
+
+	{
+		unordered_map m;
+		inspair p1 = m.emplace(pair<string, string>("hello", "world"));
+		CHECK( p1.second );
+		CHECK( (*p1.first).first == tinystl::string("hello") );
+		CHECK( (*p1.first).second == tinystl::string("world") );
+
+		inspair p2 = m.emplace(pair<string, string>("hello", "world"));
+		CHECK( !p2.second );
+		CHECK( p2.first == p1.first );
+	}
+
+	{
+		unordered_map m;
+		pair<string, string> p("hello", "world");
+		m.emplace(std::move(p));
+
+		CHECK( m.find("hello") != m.end() );
+		CHECK( p.first.size() == 0 );
+		CHECK( p.second.size() == 0 );
+	}
+}
+
+TEST(uomap_iterate) {
+	typedef tinystl::unordered_map<size_t, size_t> unordered_map;
+	{
+		unordered_map m;
+		for (size_t i = 0; i < 1000; ++i) {
+			CHECK( m.size() == i );
+			size_t count = 0;
+			for (auto it = m.begin(); it != m.end(); ++it) {
+				count++;
+			}
+			CHECK( count == i );
+
+			m.insert(tinystl::make_pair(17 * i, 101 * i));
+		}
+	}
+}

--- a/tests/unordered_set_test.cpp
+++ b/tests/unordered_set_test.cpp
@@ -1,0 +1,191 @@
+/*-
+* Copyright 2012-2018 Matthew Endsley
+* All rights reserved
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted providing that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+* IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+* ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+* DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+* OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+* HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+* STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+* IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "test.h"
+
+#include <tinystl/unordered_set.h>
+#include <tinystl/string.h>
+#include <utility>
+
+template<typename T>
+static void comparesets(const tinystl::unordered_set<T>& s, const tinystl::unordered_set<T>& expected) {
+	CHECK( s.size() == expected.size() );
+
+	typedef typename tinystl::unordered_set<T>::const_iterator iterator;
+	for (iterator it = expected.begin(), end = expected.end(); it != end; ++it) {
+		CHECK( s.find(*it) != s.end() );
+	}
+}
+
+TEST(uoset_constructor) {
+	typedef tinystl::unordered_set<int> unordered_set;
+
+	unordered_set baseline;
+	comparesets(baseline, baseline); // test on empty
+	baseline.insert(5);
+	baseline.insert(6);
+	CHECK( 2 == baseline.size() );
+	CHECK( baseline.find(5) != baseline.end() );
+	CHECK( baseline.find(6) != baseline.end() );
+	comparesets(baseline, baseline);
+
+	{
+		unordered_set s;
+
+		CHECK( s.empty() );
+		CHECK( s.size() == 0 );
+	}
+
+	{
+		unordered_set s = baseline;
+
+		comparesets(s, baseline);
+	}
+
+	{
+		unordered_set other = baseline;
+		unordered_set s = std::move(other);
+
+		comparesets(s, baseline);
+		CHECK( other.empty() );
+	}
+}
+
+TEST(uoset_assign) {
+	typedef tinystl::unordered_set<int> unordered_set;
+
+	unordered_set baseline;
+	baseline.insert(5);
+	baseline.insert(6);
+	CHECK( 2 == baseline.size() );
+	CHECK( baseline.find(5) != baseline.end() );
+	CHECK( baseline.find(6) != baseline.end() );
+	comparesets(baseline, baseline);
+
+	{
+		unordered_set s;
+		s = baseline;
+
+		comparesets(s, baseline);
+	}
+
+	{
+		unordered_set s;
+		for (int ii = 0; ii != 10; ++ii)
+			s.insert(ii);
+
+		s = baseline;
+
+		comparesets(s, baseline);
+	}
+
+	{
+		unordered_set other = baseline;
+		unordered_set s;
+		s = std::move(other);
+
+		comparesets(s, baseline);
+		CHECK( other.empty() );
+	}
+
+	{
+		unordered_set other = baseline;
+		unordered_set s;
+		for (int ii = 0; ii != 10; ++ii)
+			s.insert(ii);
+
+		s = std::move(other);
+
+		comparesets(s, baseline);
+		CHECK( other.empty() );
+	}
+}
+
+TEST(uoset_insert) {
+	typedef tinystl::unordered_set<tinystl::string> unordered_set;
+	typedef tinystl::pair<unordered_set::iterator, bool> pair;
+
+	{
+		unordered_set s;
+		s.insert("hello");
+		CHECK( s.find("hello") != s.end() );
+	}
+
+	{
+		unordered_set s;
+		pair p1 = s.insert("hello");
+		CHECK( p1.second );
+		CHECK( (*p1.first) == tinystl::string("hello") );
+
+		pair p2 = s.insert("hello");
+		CHECK( !p2.second );
+		CHECK( p2.first == p1.first );
+	}
+
+	{
+		unordered_set s;
+		s.emplace("hello");
+
+		CHECK( s.find("hello") != s.end() );
+	}
+
+	{
+		unordered_set s;
+		pair p1 = s.emplace("hello");
+		CHECK( p1.second );
+		CHECK( (*p1.first) == tinystl::string("hello") );
+
+		pair p2 = s.emplace("hello");
+		CHECK( !p2.second );
+		CHECK( p2.first == p1.first );
+	}
+
+	{
+		unordered_set s;
+		tinystl::string key("hello");
+		s.emplace(std::move(key));
+
+		CHECK( s.find("hello") != s.end() );
+		CHECK( key.size() == 0 );
+	}
+}
+
+TEST(uoset_iterate) {
+	typedef tinystl::unordered_set<int> unordered_set;
+	{
+		unordered_set s;
+		for (size_t i = 0; i < 1000; ++i) {
+			CHECK( s.size() == i );
+			size_t count = 0;
+			for (auto it = s.begin(); it != s.end(); ++it) {
+				count++;
+			}
+			CHECK( count == i );
+
+			s.insert(17 * i);
+		}
+	}
+}


### PR DESCRIPTION
A better-tested updated version of TinySTL. Replaces #340.
This library was in a very buggy state, so I made my own fork of it, patched all the issues, and made a PR there (https://github.com/mendsley/tinystl/pull/27).

I added some extra tests that were present in the tinystl repo, but not yet in the bx testsuite. All tests are passing. This time I did test the examples, and I don't get any crashes.

Also includes a small update-script to pull it the sources from the original repo and replace all `#include <TINYSTL/xxx>` with `#include <tinystl/xxx>` using `sed`.

Idk if there are cool tricks in Github to rewrite git history as if my first PR was never merged (instead of merged, reverted, and then this merged).