### PR TITLE
Small platform detection/usage improvements

### DIFF
--- a/src/mutex.cpp
+++ b/src/mutex.cpp
@@ -10,14 +10,7 @@
 #if BX_CRT_NONE
 #	include <bx/cpu.h>
 #	include <bx/crt0.h>
-#elif  BX_PLATFORM_ANDROID \
-	|| BX_PLATFORM_LINUX   \
-	|| BX_PLATFORM_IOS     \
-	|| BX_PLATFORM_OSX     \
-	|| BX_PLATFORM_PS4     \
-	|| BX_PLATFORM_RPI	   \
-	|| BX_PLATFORM_NX      \
-	|| BX_PLATFORM_VISIONOS
+#elif  BX_PLATFORM_POSIX
 #	include <pthread.h>
 #elif  BX_PLATFORM_WINDOWS \
 	|| BX_PLATFORM_WINRT   \

--- a/src/os.cpp
+++ b/src/os.cpp
@@ -19,15 +19,7 @@
 #	endif // WIN32_LEAN_AND_MEAN
 #	include <windows.h>
 #	include <psapi.h>
-#elif  BX_PLATFORM_ANDROID    \
-	|| BX_PLATFORM_EMSCRIPTEN \
-	|| BX_PLATFORM_IOS        \
-	|| BX_PLATFORM_LINUX      \
-	|| BX_PLATFORM_NX         \
-	|| BX_PLATFORM_OSX        \
-	|| BX_PLATFORM_PS4        \
-	|| BX_PLATFORM_RPI        \
-	|| BX_PLATFORM_VISIONOS
+#elif  BX_PLATFORM_POSIX
 #	include <sched.h> // sched_yield
 #	if BX_PLATFORM_IOS       \
 	|| BX_PLATFORM_OSX       \

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -14,14 +14,7 @@
 
 #if BX_CRT_NONE
 #	include <bx/crt0.h>
-#elif  BX_PLATFORM_ANDROID \
-	|| BX_PLATFORM_LINUX   \
-	|| BX_PLATFORM_IOS     \
-	|| BX_PLATFORM_OSX     \
-	|| BX_PLATFORM_PS4     \
-	|| BX_PLATFORM_RPI     \
-	|| BX_PLATFORM_NX      \
-	|| BX_PLATFORM_VISIONOS
+#elif  BX_PLATFORM_POSIX
 #	include <pthread.h>
 #	if BX_PLATFORM_LINUX && (BX_CRT_GLIBC < 21200)
 #		include <sys/prctl.h>

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -16,9 +16,6 @@
 #	include <bx/crt0.h>
 #elif  BX_PLATFORM_POSIX
 #	include <pthread.h>
-#	if BX_PLATFORM_LINUX && (BX_CRT_GLIBC < 21200)
-#		include <sys/prctl.h>
-#	endif // BX_PLATFORM_
 #elif  BX_PLATFORM_WINDOWS \
 	|| BX_PLATFORM_WINRT   \
 	|| BX_PLATFORM_XBOXONE \
@@ -236,7 +233,7 @@ namespace bx
 	|| BX_PLATFORM_IOS   \
 	|| BX_PLATFORM_VISIONOS
 		pthread_setname_np(_name);
-#elif (BX_CRT_GLIBC >= 21200)
+#elif BX_CRT_GLIBC
 		pthread_setname_np(ti->m_handle, _name);
 #elif BX_PLATFORM_LINUX
 		prctl(PR_SET_NAME,_name, 0, 0, 0);


### PR DESCRIPTION
- consistently use `BX_PLATFORM_POSIX` in more places
- drop support for glibc < 2.12

See the commit messages for longer explanations.