### PR TITLE
platform: bridge legacy lowercase emscripten version macros

### DIFF
--- a/include/bx/platform.h
+++ b/include/bx/platform.h
@@ -204,6 +204,16 @@
 #	define BX_PLATFORM_OSX __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__
 #elif defined(__wasm__)
 #	include <emscripten/version.h>
+   // emscripten <= 4.0.23 only defined the lowercase version macros
+   // (__EMSCRIPTEN_major__, _minor_, _tiny_); 4.0.24+ added uppercase as
+   // primary and kept lowercase as deprecated aliases. Bridge the older
+   // emsdk so bx (and downstream code that consumes BX_PLATFORM_EMSCRIPTEN)
+   // can rely on the uppercase form uniformly.
+#	if !defined(__EMSCRIPTEN_MAJOR__) && defined(__EMSCRIPTEN_major__)
+#		define __EMSCRIPTEN_MAJOR__ __EMSCRIPTEN_major__
+#		define __EMSCRIPTEN_MINOR__ __EMSCRIPTEN_minor__
+#		define __EMSCRIPTEN_TINY__  __EMSCRIPTEN_tiny__
+#	endif
 #	undef  BX_PLATFORM_EMSCRIPTEN
 #	define BX_PLATFORM_EMSCRIPTEN (__EMSCRIPTEN_MAJOR__ * 10000 + __EMSCRIPTEN_MINOR__ * 100 + __EMSCRIPTEN_TINY__)
 #elif defined(__ORBIS__)


### PR DESCRIPTION
## Motivation

PR #374 switched all of bx's references to the uppercase emscripten
version macros (`__EMSCRIPTEN_MAJOR__`, `__EMSCRIPTEN_MINOR__`,
`__EMSCRIPTEN_TINY__`). That's the right forward direction —
[emscripten-core/emscripten#26180](https://github.com/emscripten-core/emscripten/pull/26180)
made uppercase primary and deprecated lowercase.

But that emscripten change landed in 4.0.24 (Jan 27, 2026). Users on
emsdk **<= 4.0.23** still have only the lowercase forms in
`<emscripten/version.h>`. Against current bx master, their builds fail
with:

```
bx/src/os.cpp:60:3: error: unknown type name 'timespec'
bx/src/os.cpp:60:21: error: unknown type name 'time_t'
…
```

Because `__EMSCRIPTEN_MAJOR__` is undefined → the preprocessor expression
`(__EMSCRIPTEN_MAJOR__ * 10000 + …)` evaluates to 0 → `BX_PLATFORM_EMSCRIPTEN`
is 0 → `BX_PLATFORM_POSIX` is 0 → `os.cpp` skips its `<time.h>` /
`<sched.h>` / `<dlfcn.h>` includes.

## Change

Inside the `defined(__wasm__)` branch, after `#include <emscripten/version.h>`,
add a small bridge:

```c
#if !defined(__EMSCRIPTEN_MAJOR__) && defined(__EMSCRIPTEN_major__)
#  define __EMSCRIPTEN_MAJOR__ __EMSCRIPTEN_major__
#  define __EMSCRIPTEN_MINOR__ __EMSCRIPTEN_minor__
#  define __EMSCRIPTEN_TINY__  __EMSCRIPTEN_tiny__
#endif
```

This is a no-op on emsdk 4.0.24+ (uppercase already defined). On older
emsdk it aliases the lowercase forms to uppercase so the rest of bx —
including line 357's `BX_STRINGIZE(__EMSCRIPTEN_MAJOR__)` — works
uniformly.

## Notes

- Defining `__EMSCRIPTEN_*` from outside emscripten itself is admittedly
  in their reserved namespace, but it's only done when the macros are
  genuinely absent, and as deprecated aliases per emscripten's own
  template. An alternative would be to introduce bx-namespaced helper
  macros (`BX_EMSCRIPTEN_VERSION_MAJOR` etc.) and use them at the two
  consumer sites; happy to flip if you prefer that shape.
- Tested against emsdk 4.0.23 (lowercase-only): bx builds clean. Newer
  emsdk paths are unaffected.