### PR TITLE
platform.h: detect MSVC ARM64 as 64-bit and raise 32-bit Windows minimum

### DIFF
--- a/include/bx/platform.h
+++ b/include/bx/platform.h
@@ -123,6 +123,8 @@
 #if defined(__x86_64__)    \
  || defined(_M_X64)        \
  || defined(__aarch64__)   \
+ || defined(_M_ARM64)      \
+ || defined(_M_ARM64EC)    \
  || defined(__64BIT__)     \
  || defined(__mips64)      \
  || defined(__powerpc64__) \
@@ -170,9 +172,9 @@
 #				define WINVER 0x0601
 #				define _WIN32_WINNT 0x0601
 #			else
-//				Windows Server 2003 with SP1, Windows XP with SP2 and above
-#				define WINVER 0x0502
-#				define _WIN32_WINNT 0x0502
+//				When building 32-bit target Win7 and above.
+#				define WINVER 0x0601
+#				define _WIN32_WINNT 0x0601
 #			endif // BX_ARCH_64BIT
 #		endif // !defined(WINVER) && !defined(_WIN32_WINNT)
 #		define BX_PLATFORM_WINDOWS _WIN32_WINNT


### PR DESCRIPTION
## Summary

Two related Windows fixes in `include/bx/platform.h`:

### 1. Detect MSVC ARM64 as 64-bit

The `BX_ARCH_64BIT` detection lists `__aarch64__` (GCC/Clang) but not MSVC's `_M_ARM64` / `_M_ARM64EC`. As a result, Windows-on-ARM64 built with MSVC is treated as a **32-bit** architecture, which is incorrect and affects everything keyed off `BX_ARCH_64BIT` (pointer-size assumptions, the Windows version default below, etc.). Added `_M_ARM64` and `_M_ARM64EC` to the 64-bit list.

### 2. Raise the 32-bit Windows minimum

The 32-bit Windows branch defaulted `WINVER` / `_WIN32_WINNT` to `0x0502` (Windows XP / Server 2003). That predates APIs modern Windows SDK headers reference unconditionally — e.g. the ETW `EventRegister` / `EventUnregister` / `EventWriteTransfer` family in `<evntprov.h>`, which is only declared for `_WIN32_WINNT >= 0x0600`. Building a 32-bit target that transitively includes such headers fails with `error C3861: 'EventRegister': identifier not found`.

Raised the 32-bit default to `0x0601` (Windows 7), matching the existing 64-bit branch. With both fixes, x86, x64 and ARM64 Windows targets default to a consistent Windows 7 baseline. Callers that need a different target can still define `WINVER` / `_WIN32_WINNT` themselves — the defaults remain guarded by `!defined(...)`.

## Testing

Compiled a TU including `<bx/platform.h>` with MSVC for `x86`, `x64` and `arm64`, asserting `_WIN32_WINNT >= 0x0600` (and `BX_ARCH_64BIT == 64` for ARM64) — all pass. Against the previous code, the `x86` and `arm64` targets fail those assertions (they resolved to `0x0502`).
